### PR TITLE
feat: 회원가입 및 계정 정보 찾기 페이지 구현

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -38,6 +38,16 @@ const router = createRouter({
       name: 'login',
       component: () => import('@/views/LoginView.vue'),
     },
+    {
+      path: '/signup',
+      name: 'signup',
+      component: () => import('@/views/SignUpView.vue'),
+    },
+    {
+      path: '/find-account',
+      name: 'find-account',
+      component: () => import('@/views/FindAccountInfoView.vue'),
+    },
   ],
 })
 

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -2,7 +2,7 @@ import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import axios from 'axios'
 import apiClient from '@/services/api'
-import type { LoginRequestDto } from '@/types/auth'
+import type { LoginRequestDto, SignupRequestDto } from '@/types/auth'
 
 export interface User {
   email: string
@@ -79,6 +79,52 @@ export const useAuthStore = defineStore('auth', () => {
       clearAuthentication()
     }
   }
+  
+  async function signup(signupRequest: SignupRequestDto): Promise<boolean> {
+    try {
+      await apiClient.post('/auth/signup', signupRequest);
+      return true;
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error)) {
+        // You can refine error handling here, e.g., by returning the error message
+        alert(error.response?.data?.message || '회원가입 중 오류가 발생했습니다.');
+        console.error('Signup failed:', error.response?.data || error.message);
+      } else {
+        alert('알 수 없는 오류가 발생했습니다.');
+        console.error('An unexpected error occurred during signup:', error);
+      }
+      return false;
+    }
+  }
+
+  async function findEmailByNickname(nickname: string): Promise<string> {
+    try {
+      const response = await apiClient.get(`/auth/find-email/${nickname}`);
+      return response.data.email;
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error)) {
+        throw new Error(error.response?.data?.message || '이메일 찾기 중 오류가 발생했습니다.');
+      } else {
+        throw new Error('알 수 없는 오류가 발생했습니다.');
+      }
+    }
+  }
+
+  async function resetPassword(email: string): Promise<boolean> {
+    try {
+      await apiClient.post('/auth/reset-password', { email });
+      return true;
+    } catch (error: unknown) {
+      // This endpoint fails silently on the backend, so frontend errors are less likely
+      // unless there's a network issue or validation failure.
+      if (axios.isAxiosError(error)) {
+        console.error('Password reset failed:', error.response?.data || error.message);
+      } else {
+        console.error('An unexpected error occurred during password reset:', error);
+      }
+      return false;
+    }
+  }
 
   // This is the key action for session persistence
   async function refreshAccessToken() {
@@ -86,22 +132,16 @@ export const useAuthStore = defineStore('auth', () => {
       isInitialized.value = true
       return
     }
-
     try {
       const response = await apiClient.post('/auth/refresh')
       const { accessToken: token, expiresIn } = response.data
-
-      // We have a new access token, but we need the user data.
-      // It's already in localStorage from the a initial login.
       const storedUser = localStorage.getItem('user')
       if (storedUser) {
         setAuthenticated(token, JSON.parse(storedUser), expiresIn)
       } else {
-        // This case is unlikely if refresh succeeds, but handle it just in case.
         throw new Error('User data not found in localStorage after token refresh.')
       }
     } catch (error: unknown) {
-      // Refresh failed (e.g., expired refresh token), ensure user is logged out.
       if (axios.isAxiosError(error)) {
         console.error('Refresh token failed:', error.response?.data || error.message)
       } else {
@@ -121,6 +161,9 @@ export const useAuthStore = defineStore('auth', () => {
     isInitialized,
     login,
     logout,
+    signup,
+    findEmailByNickname,
+    resetPassword,
     refreshAccessToken
   }
 })

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -2,3 +2,9 @@ export interface LoginRequestDto {
   email: string;
   password: string;
 }
+
+export interface SignupRequestDto {
+  email: string;
+  password: string;
+  nickname: string;
+}

--- a/src/views/FindAccountInfoView.vue
+++ b/src/views/FindAccountInfoView.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+// For Find ID
+const nickname = ref('')
+const foundEmail = ref<string | null>(null)
+const findIdError = ref<string | null>(null)
+const isFindIdLoading = ref(false)
+
+// For Find Password
+const emailForPassword = ref('')
+const isPasswordResetLoading = ref(false)
+const isPasswordResetSubmitted = ref(false)
+
+async function handleFindId() {
+  if (!nickname.value) return
+  isFindIdLoading.value = true
+  foundEmail.value = null
+  findIdError.value = null
+  try {
+    const result = await authStore.findEmailByNickname(nickname.value)
+    foundEmail.value = result
+  } catch (error: any) {
+    findIdError.value = error.message || '아이디 찾기 중 오류가 발생했습니다.'
+  } finally {
+    isFindIdLoading.value = false
+  }
+}
+
+async function handlePasswordReset() {
+  if (!emailForPassword.value) return
+  isPasswordResetLoading.value = true
+  try {
+    await authStore.resetPassword(emailForPassword.value);
+    isPasswordResetSubmitted.value = true
+  } finally {
+    isPasswordResetLoading.value = false
+  }
+}
+
+function goToHome() {
+  router.push('/')
+}
+
+function goToLogin() {
+  router.push('/login')
+}
+</script>
+
+<template>
+  <div class="flex min-h-screen items-center justify-center bg-[#F5F5F5] p-4 font-sans">
+    <div class="w-full max-w-sm space-y-8">
+      <!-- Find ID Card -->
+      <div
+        class="rounded-xl border-2 border-[#2C2C2C] bg-white p-8 shadow-[3px_3px_0px_0px_rgba(44,44,44,0.1)] transition-all"
+      >
+        <div class="text-center">
+          <h1
+            @click="goToHome"
+            class="mb-2 cursor-pointer text-3xl font-black text-[#E88555] transition-transform hover:scale-105"
+          >
+            아이디 찾기
+          </h1>
+          <p class="mb-6 text-sm font-medium text-gray-500">
+            가입 시 사용한 닉네임을 입력해주세요.
+          </p>
+        </div>
+
+        <form @submit.prevent="handleFindId" class="space-y-4">
+          <div>
+            <label for="nickname" class="sr-only">닉네임</label>
+            <input
+              type="text"
+              id="nickname"
+              v-model="nickname"
+              placeholder="닉네임"
+              required
+              class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
+            />
+          </div>
+          <button
+            type="submit"
+            :disabled="isFindIdLoading"
+            class="flex w-full items-center justify-center rounded-lg border-2 border-[#2C2C2C] bg-[#E88555] p-3 font-black text-white transition-all hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_#2C2C2C] focus:outline-none disabled:opacity-70"
+          >
+            <div
+              v-if="isFindIdLoading"
+              class="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+            ></div>
+            <span>{{ isFindIdLoading ? '찾는 중...' : '이메일 찾기' }}</span>
+          </button>
+        </form>
+
+        <div v-if="foundEmail" class="mt-4 rounded-lg bg-green-100 p-3 text-center text-sm font-bold text-green-800">
+          회원님의 이메일은<br/>{{ foundEmail }} 입니다.
+        </div>
+        <div v-if="findIdError" class="mt-4 rounded-lg bg-red-100 p-3 text-center text-sm font-medium text-red-700">
+          {{ findIdError }}
+        </div>
+      </div>
+
+      <!-- Find Password Card -->
+      <div
+        class="rounded-xl border-2 border-[#2C2C2C] bg-white p-8 shadow-[3px_3px_0px_0px_rgba(44,44,44,0.1)] transition-all"
+      >
+        <div class="text-center">
+          <h1
+            class="mb-2 text-3xl font-black text-[#E88555]"
+          >
+            비밀번호 찾기
+          </h1>
+          <p class="mb-6 text-sm font-medium text-gray-500">
+            가입한 이메일을 입력하시면 임시 비밀번호를 보내드립니다.
+          </p>
+        </div>
+
+        <div v-if="isPasswordResetSubmitted" class="text-center">
+          <p class="mb-4 text-sm font-medium text-gray-700">
+            입력하신 이메일로 임시 비밀번호가 발송되었습니다.<br />
+            메일을 확인해주세요. (스팸함도 확인해보세요)
+          </p>
+        </div>
+        <form v-else @submit.prevent="handlePasswordReset" class="space-y-4">
+          <div>
+            <label for="email" class="sr-only">이메일</label>
+            <input
+              type="email"
+              id="email"
+              v-model="emailForPassword"
+              placeholder="가입한 이메일 주소"
+              required
+              class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
+            />
+          </div>
+          <button
+            type="submit"
+            :disabled="isPasswordResetLoading"
+            class="flex w-full items-center justify-center rounded-lg border-2 border-[#2C2C2C] bg-[#E88555] p-3 font-black text-white transition-all hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_#2C2C2C] focus:outline-none disabled:opacity-70"
+          >
+            <div
+              v-if="isPasswordResetLoading"
+              class="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+            ></div>
+            <span>{{ isPasswordResetLoading ? '전송 중...' : '임시 비밀번호 전송' }}</span>
+          </button>
+        </form>
+      </div>
+       <div class="text-center text-xs font-medium text-gray-500">
+        <a @click.prevent="goToLogin" href="#" class="hover:text-[#E88555] hover:underline">로그인 페이지로 돌아가기</a>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/views/SignUpView.vue
+++ b/src/views/SignUpView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 
@@ -8,21 +8,36 @@ const authStore = useAuthStore()
 
 const email = ref('')
 const password = ref('')
+const passwordConfirm = ref('')
+const nickname = ref('')
 const isLoading = ref(false)
+const errorMessage = ref('')
 
-async function handleLogin() {
+const isPasswordMismatch = computed(() => {
+  return password.value && passwordConfirm.value && password.value !== passwordConfirm.value
+})
+
+async function handleSignUp() {
+  if (isPasswordMismatch.value) {
+    errorMessage.value = '비밀번호가 일치하지 않습니다.'
+    return
+  }
+  if (!password.value.match(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/)) {
+    errorMessage.value = '비밀번호는 8자 이상이며, 대/소문자, 숫자, 특수문자를 포함해야 합니다.'
+    return
+  }
+  
   isLoading.value = true
+  errorMessage.value = ''
   try {
-    const success = await authStore.login({
+    const success = await authStore.signup({
       email: email.value,
-      password: password.value
+      password: password.value,
+      nickname: nickname.value
     })
-
     if (success) {
-      router.push('/') // Redirect to home on successful login
-    } else {
-      alert('로그인에 실패했습니다. 아이디와 비밀번호를 확인해주세요.')
-      password.value = '' // Clear password field
+      alert('회원가입에 성공했습니다! 로그인 페이지로 이동합니다.');
+      router.push('/login')
     }
   } finally {
     isLoading.value = false
@@ -33,12 +48,12 @@ function goToHome() {
   router.push('/')
 }
 
-function goToFindAccount() {
-  router.push('/find-account')
+function goToLogin() {
+  router.push('/login')
 }
 
-function goToSignUp() {
-  router.push('/signup')
+function goToFindAccount() {
+  router.push('/find-account')
 }
 </script>
 
@@ -55,11 +70,11 @@ function goToSignUp() {
           TRIT
         </h1>
         <p class="mb-8 text-sm font-medium text-gray-500">
-          여행의 모든 순간, TRIT과 함께
+          새로운 계정을 만들어 여행을 기록하세요
         </p>
       </div>
 
-      <form @submit.prevent="handleLogin" class="space-y-5">
+      <form @submit.prevent="handleSignUp" class="space-y-4">
         <div>
           <label for="email" class="sr-only">이메일</label>
           <input
@@ -67,6 +82,18 @@ function goToSignUp() {
             id="email"
             v-model="email"
             placeholder="이메일"
+            required
+            class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
+          />
+        </div>
+
+        <div>
+          <label for="nickname" class="sr-only">닉네임</label>
+          <input
+            type="text"
+            id="nickname"
+            v-model="nickname"
+            placeholder="닉네임"
             required
             class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
           />
@@ -84,23 +111,38 @@ function goToSignUp() {
           />
         </div>
 
+        <div>
+          <label for="passwordConfirm" class="sr-only">비밀번호 확인</label>
+          <input
+            type="password"
+            id="passwordConfirm"
+            v-model="passwordConfirm"
+            placeholder="비밀번호 확인"
+            required
+            class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
+            :class="{ 'border-red-500': isPasswordMismatch }"
+          />
+        </div>
+        
+        <p v-if="errorMessage" class="text-xs text-red-500 text-center">{{ errorMessage }}</p>
+
         <button
           type="submit"
-          :disabled="isLoading"
+          :disabled="isLoading || isPasswordMismatch"
           class="flex w-full items-center justify-center rounded-lg border-2 border-[#2C2C2C] bg-[#E88555] p-3 font-black text-white transition-all hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_#2C2C2C] focus:outline-none disabled:opacity-70 disabled:hover:translate-x-0 disabled:hover:shadow-none"
         >
           <div
             v-if="isLoading"
             class="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
           ></div>
-          <span>{{ isLoading ? '로그인 중...' : '로그인' }}</span>
+          <span>{{ isLoading ? '가입하는 중...' : '회원가입' }}</span>
         </button>
       </form>
 
       <div class="mt-6 text-center text-xs font-medium text-gray-500">
         <a @click.prevent="goToFindAccount" href="#" class="hover:text-[#E88555] hover:underline">ID/비밀번호 찾기</a>
         <span class="mx-2">|</span>
-        <a @click.prevent="goToSignUp" href="#" class="hover:text-[#E88555] hover:underline">회원가입</a>
+        <a @click.prevent="goToLogin" href="#" class="hover:text-[#E88555] hover:underline">로그인</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### 📄 회원가입 페이지 

<img width="447" height="573" alt="image" src="https://github.com/user-attachments/assets/7a5e9ad1-06f8-4c76-adfc-7547b9a21964" />

- 이메일 형식 준수 필요
- 중복된 이메일 입력 시 에러 반환
- 중복된 닉네임 입력 시 에러 반환
- 비밀번호 정책 준수 필요

---

### 📄 ID/비밀번호 찾기 페이지

<img width="437" height="686" alt="image" src="https://github.com/user-attachments/assets/3061387d-79e9-4113-b920-0a2690ad2dc6" />

- ID 찾기: 닉네임을 입력하면 마스킹된 이메일을 반환
- 비밀번호 찾기: 이메일을 입력하면 재발급된 임시 비밀번호를 해당 이메일로 전송

---

### 📅 향후 계획
- **로그인, 회원가입, ID/비밀번호 찾기 페이지**에서 **메인 페이지로 돌아가는 버튼이 필요**합니다.
