### PR TITLE
feat: 회원가입/로그인/계정 찾기 페이지에 Navigation Bar 추가

### DIFF
--- a/src/views/FindAccountInfoView.vue
+++ b/src/views/FindAccountInfoView.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import TravelNavbar from '@/components/common/TravelNavbar.vue' // Import TravelNavbar
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -43,8 +44,21 @@ async function handlePasswordReset() {
   }
 }
 
-function goToHome() {
-  router.push('/')
+function handleNavigation(page: 'main' | 'search' | 'trips' | 'log') {
+  switch (page) {
+    case 'main':
+      router.push({ name: 'home' })
+      break
+    case 'search':
+      router.push({ name: 'search' })
+      break
+    case 'trips':
+      router.push({ name: 'trips' })
+      break
+    case 'log':
+      router.push({ name: 'log' })
+      break
+  }
 }
 
 function goToLogin() {
@@ -53,105 +67,119 @@ function goToLogin() {
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-[#F5F5F5] p-4 font-sans">
-    <div class="w-full max-w-sm space-y-8">
-      <!-- Find ID Card -->
-      <div
-        class="rounded-xl border-2 border-[#2C2C2C] bg-white p-8 shadow-[3px_3px_0px_0px_rgba(44,44,44,0.1)] transition-all"
-      >
-        <div class="text-center">
-          <h1
-            @click="goToHome"
-            class="mb-2 cursor-pointer text-3xl font-black text-[#E88555] transition-transform hover:scale-105"
-          >
-            아이디 찾기
-          </h1>
-          <p class="mb-6 text-sm font-medium text-gray-500">
-            가입 시 사용한 닉네임을 입력해주세요.
-          </p>
-        </div>
+  <div class="relative min-h-screen bg-[#F5F5F5] font-sans pt-[100px]">
+    <!-- TravelNavbar component -->
+    <TravelNavbar currentPage="main" @navigate="handleNavigation" />
 
-        <form @submit.prevent="handleFindId" class="space-y-4">
-          <div>
-            <label for="nickname" class="sr-only">닉네임</label>
-            <input
-              type="text"
-              id="nickname"
-              v-model="nickname"
-              placeholder="닉네임"
-              required
-              class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
-            />
-          </div>
-          <button
-            type="submit"
-            :disabled="isFindIdLoading"
-            class="flex w-full items-center justify-center rounded-lg border-2 border-[#2C2C2C] bg-[#E88555] p-3 font-black text-white transition-all hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_#2C2C2C] focus:outline-none disabled:opacity-70"
+    <!-- Main Content -->
+    <div class="flex min-h-screen items-center justify-center p-4">
+      <div class="w-full max-w-sm">
+        <div class="space-y-8">
+          <!-- Find ID Card -->
+          <div
+            class="rounded-xl border-2 border-[#2C2C2C] bg-white p-8 shadow-[3px_3px_0px_0px_rgba(44,44,44,0.1)] transition-all"
           >
+            <div class="text-center">
+              <h1 class="mb-2 text-3xl font-black text-[#E88555]">아이디 찾기</h1>
+              <p class="mb-6 text-sm font-medium text-gray-500">
+                가입 시 사용한 닉네임을 입력해주세요.
+              </p>
+            </div>
+
+            <form @submit.prevent="handleFindId" class="space-y-4">
+              <div>
+                <label for="nickname" class="sr-only">닉네임</label>
+                <input
+                  type="text"
+                  id="nickname"
+                  v-model="nickname"
+                  placeholder="닉네임"
+                  required
+                  class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
+                />
+              </div>
+              <button
+                type="submit"
+                :disabled="isFindIdLoading"
+                class="flex w-full items-center justify-center rounded-lg border-2 border-[#2C2C2C] bg-[#E88555] p-3 font-black text-white transition-all hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_#2C2C2C] focus:outline-none disabled:opacity-70"
+              >
+                <div
+                  v-if="isFindIdLoading"
+                  class="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+                ></div>
+                <span>{{ isFindIdLoading ? '찾는 중...' : '이메일 찾기' }}</span>
+              </button>
+            </form>
+
             <div
-              v-if="isFindIdLoading"
-              class="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
-            ></div>
-            <span>{{ isFindIdLoading ? '찾는 중...' : '이메일 찾기' }}</span>
-          </button>
-        </form>
-
-        <div v-if="foundEmail" class="mt-4 rounded-lg bg-green-100 p-3 text-center text-sm font-bold text-green-800">
-          회원님의 이메일은<br/>{{ foundEmail }} 입니다.
-        </div>
-        <div v-if="findIdError" class="mt-4 rounded-lg bg-red-100 p-3 text-center text-sm font-medium text-red-700">
-          {{ findIdError }}
-        </div>
-      </div>
-
-      <!-- Find Password Card -->
-      <div
-        class="rounded-xl border-2 border-[#2C2C2C] bg-white p-8 shadow-[3px_3px_0px_0px_rgba(44,44,44,0.1)] transition-all"
-      >
-        <div class="text-center">
-          <h1
-            class="mb-2 text-3xl font-black text-[#E88555]"
-          >
-            비밀번호 찾기
-          </h1>
-          <p class="mb-6 text-sm font-medium text-gray-500">
-            가입한 이메일을 입력하시면 임시 비밀번호를 보내드립니다.
-          </p>
-        </div>
-
-        <div v-if="isPasswordResetSubmitted" class="text-center">
-          <p class="mb-4 text-sm font-medium text-gray-700">
-            입력하신 이메일로 임시 비밀번호가 발송되었습니다.<br />
-            메일을 확인해주세요. (스팸함도 확인해보세요)
-          </p>
-        </div>
-        <form v-else @submit.prevent="handlePasswordReset" class="space-y-4">
-          <div>
-            <label for="email" class="sr-only">이메일</label>
-            <input
-              type="email"
-              id="email"
-              v-model="emailForPassword"
-              placeholder="가입한 이메일 주소"
-              required
-              class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
-            />
-          </div>
-          <button
-            type="submit"
-            :disabled="isPasswordResetLoading"
-            class="flex w-full items-center justify-center rounded-lg border-2 border-[#2C2C2C] bg-[#E88555] p-3 font-black text-white transition-all hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_#2C2C2C] focus:outline-none disabled:opacity-70"
-          >
+              v-if="foundEmail"
+              class="mt-4 rounded-lg bg-green-100 p-3 text-center text-sm font-bold text-green-800"
+            >
+              회원님의 이메일은<br />{{ foundEmail }} 입니다.
+            </div>
             <div
-              v-if="isPasswordResetLoading"
-              class="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
-            ></div>
-            <span>{{ isPasswordResetLoading ? '전송 중...' : '임시 비밀번호 전송' }}</span>
-          </button>
-        </form>
-      </div>
-       <div class="text-center text-xs font-medium text-gray-500">
-        <a @click.prevent="goToLogin" href="#" class="hover:text-[#E88555] hover:underline">로그인 페이지로 돌아가기</a>
+              v-if="findIdError"
+              class="mt-4 rounded-lg bg-red-100 p-3 text-center text-sm font-medium text-red-700"
+            >
+              {{ findIdError }}
+            </div>
+          </div>
+
+          <!-- Find Password Card -->
+          <div
+            class="rounded-xl border-2 border-[#2C2C2C] bg-white p-8 shadow-[3px_3px_0px_0px_rgba(44,44,44,0.1)] transition-all"
+          >
+            <div class="text-center">
+              <h1 class="mb-2 text-3xl font-black text-[#E88555]">비밀번호 찾기</h1>
+              <p class="mb-6 text-sm font-medium text-gray-500">
+                가입한 이메일을 입력하시면 임시 비밀번호를 보내드립니다.
+              </p>
+            </div>
+
+            <div v-if="isPasswordResetSubmitted" class="text-center">
+              <p class="mb-4 text-sm font-medium text-gray-700">
+                입력하신 이메일로 임시 비밀번호가 발송되었습니다.<br />
+                메일을 확인해주세요. (스팸함도 확인해보세요)
+              </p>
+            </div>
+            <form v-else @submit.prevent="handlePasswordReset" class="space-y-4">
+              <div>
+                <label for="email" class="sr-only">이메일</label>
+                <input
+                  type="email"
+                  id="email"
+                  v-model="emailForPassword"
+                  placeholder="가입한 이메일 주소"
+                  required
+                  class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
+                />
+              </div>
+              <button
+                type="submit"
+                :disabled="isPasswordResetLoading"
+                class="flex w-full items-center justify-center rounded-lg border-2 border-[#2C2C2C] bg-[#E88555] p-3 font-black text-white transition-all hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_#2C2C2C] focus:outline-none disabled:opacity-70"
+              >
+                <div
+                  v-if="isPasswordResetLoading"
+                  class="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+                ></div>
+                <span>{{ isPasswordResetLoading ? '전송 중...' : '임시 비밀번호 전송' }}</span>
+              </button>
+            </form>
+          </div>
+        </div>
+
+        <hr class="my-6 border-gray-300" />
+
+        <div class="text-center text-sm font-medium text-gray-500">
+          <p>
+            계정이 기억나셨다면
+            <router-link to="/login" class="font-bold text-[#E88555] hover:underline"
+              >로그인</router-link
+            >
+            해보시겠어요?
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import TravelNavbar from '@/components/common/TravelNavbar.vue' // Import TravelNavbar
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -29,8 +30,21 @@ async function handleLogin() {
   }
 }
 
-function goToHome() {
-  router.push('/')
+function handleNavigation(page: 'main' | 'search' | 'trips' | 'log') {
+  switch (page) {
+    case 'main':
+      router.push({ name: 'home' })
+      break
+    case 'search':
+      router.push({ name: 'search' })
+      break
+    case 'trips':
+      router.push({ name: 'trips' })
+      break
+    case 'log':
+      router.push({ name: 'log' })
+      break
+  }
 }
 
 function goToFindAccount() {
@@ -43,64 +57,73 @@ function goToSignUp() {
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-[#F5F5F5] p-4 font-sans">
-    <div
-      class="w-full max-w-sm rounded-xl border-2 border-[#2C2C2C] bg-white p-8 shadow-[3px_3px_0px_0px_rgba(44,44,44,0.1)] transition-all hover:shadow-[4px_4px_0px_0px_rgba(44,44,44,0.15)] hover:translate-x-[-1px] hover:translate-y-[-1px]"
-    >
-      <div class="text-center">
-        <h1
-          @click="goToHome"
-          class="mb-2 cursor-pointer text-4xl font-black text-[#E88555] transition-transform hover:scale-105"
-        >
-          TRIT
-        </h1>
-        <p class="mb-8 text-sm font-medium text-gray-500">
-          여행의 모든 순간, TRIT과 함께
-        </p>
-      </div>
+  <div class="relative min-h-screen bg-[#F5F5F5] font-sans pt-[100px]">
+    <!-- TravelNavbar component -->
+    <TravelNavbar currentPage="main" @navigate="handleNavigation" />
 
-      <form @submit.prevent="handleLogin" class="space-y-5">
-        <div>
-          <label for="email" class="sr-only">이메일</label>
-          <input
-            type="email"
-            id="email"
-            v-model="email"
-            placeholder="이메일"
-            required
-            class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
-          />
+    <!-- Main Content -->
+    <div class="flex min-h-screen items-center justify-center p-4">
+      <div
+        class="w-full max-w-sm rounded-xl border-2 border-[#2C2C2C] bg-white p-8 shadow-[3px_3px_0px_0px_rgba(44,44,44,0.1)]"
+      >
+        <div class="text-center">
+          <h2 class="mb-2 text-3xl font-bold text-gray-800">로그인</h2>
+          <p class="mb-8 text-sm font-medium text-gray-500">여행의 모든 순간, TRIT과 함께</p>
         </div>
 
-        <div>
-          <label for="password" class="sr-only">비밀번호</label>
-          <input
-            type="password"
-            id="password"
-            v-model="password"
-            placeholder="비밀번호"
-            required
-            class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
-          />
+        <form @submit.prevent="handleLogin" class="space-y-5">
+          <div>
+            <label for="email" class="sr-only">이메일</label>
+            <input
+              type="email"
+              id="email"
+              v-model="email"
+              placeholder="이메일"
+              required
+              class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
+            />
+          </div>
+
+          <div>
+            <label for="password" class="sr-only">비밀번호</label>
+            <input
+              type="password"
+              id="password"
+              v-model="password"
+              placeholder="비밀번호"
+              required
+              class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
+            />
+          </div>
+
+          <button
+            type="submit"
+            :disabled="isLoading"
+            class="flex w-full items-center justify-center rounded-lg border-2 border-[#2C2C2C] bg-[#E88555] p-3 font-black text-white transition-all hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_#2C2C2C] focus:outline-none disabled:opacity-70 disabled:hover:translate-x-0 disabled:hover:shadow-none"
+          >
+            <div
+              v-if="isLoading"
+              class="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+            ></div>
+            <span>{{ isLoading ? '로그인 중...' : '로그인' }}</span>
+          </button>
+        </form>
+
+        <hr class="my-6 border-gray-300" />
+
+        <div class="space-y-3 text-center text-xs font-medium text-gray-500">
+          <p>
+            아이디나 비밀번호를 잊었을 때는,
+            <router-link to="/find-account" class="font-bold text-[#E88555] hover:underline"
+            >여기</router-link
+            >를 눌러주세요.
+          </p>
+          <p>
+            회원가입은
+            <router-link to="/signup" class="font-bold text-[#E88555] hover:underline">여기</router-link
+            >에서 할 수 있습니다.
+          </p>
         </div>
-
-        <button
-          type="submit"
-          :disabled="isLoading"
-          class="flex w-full items-center justify-center rounded-lg border-2 border-[#2C2C2C] bg-[#E88555] p-3 font-black text-white transition-all hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_#2C2C2C] focus:outline-none disabled:opacity-70 disabled:hover:translate-x-0 disabled:hover:shadow-none"
-        >
-          <div
-            v-if="isLoading"
-            class="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
-          ></div>
-          <span>{{ isLoading ? '로그인 중...' : '로그인' }}</span>
-        </button>
-      </form>
-
-      <div class="mt-6 text-center text-xs font-medium text-gray-500">
-        <a @click.prevent="goToFindAccount" href="#" class="hover:text-[#E88555] hover:underline">ID/비밀번호 찾기</a>
-        <span class="mx-2">|</span>
-        <a @click.prevent="goToSignUp" href="#" class="hover:text-[#E88555] hover:underline">회원가입</a>
       </div>
     </div>
   </div>

--- a/src/views/SignUpView.vue
+++ b/src/views/SignUpView.vue
@@ -2,6 +2,7 @@
 import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import TravelNavbar from '@/components/common/TravelNavbar.vue' // Import TravelNavbar
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -44,8 +45,21 @@ async function handleSignUp() {
   }
 }
 
-function goToHome() {
-  router.push('/')
+function handleNavigation(page: 'main' | 'search' | 'trips' | 'log') {
+  switch (page) {
+    case 'main':
+      router.push({ name: 'home' })
+      break
+    case 'search':
+      router.push({ name: 'search' })
+      break
+    case 'trips':
+      router.push({ name: 'trips' })
+      break
+    case 'log':
+      router.push({ name: 'log' })
+      break
+  }
 }
 
 function goToLogin() {
@@ -58,91 +72,95 @@ function goToFindAccount() {
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-[#F5F5F5] p-4 font-sans">
-    <div
-      class="w-full max-w-sm rounded-xl border-2 border-[#2C2C2C] bg-white p-8 shadow-[3px_3px_0px_0px_rgba(44,44,44,0.1)] transition-all hover:shadow-[4px_4px_0px_0px_rgba(44,44,44,0.15)] hover:translate-x-[-1px] hover:translate-y-[-1px]"
-    >
-      <div class="text-center">
-        <h1
-          @click="goToHome"
-          class="mb-2 cursor-pointer text-4xl font-black text-[#E88555] transition-transform hover:scale-105"
-        >
-          TRIT
-        </h1>
-        <p class="mb-8 text-sm font-medium text-gray-500">
-          새로운 계정을 만들어 여행을 기록하세요
-        </p>
-      </div>
+  <div class="relative min-h-screen bg-[#F5F5F5] font-sans pt-[100px]">
+    <!-- TravelNavbar component -->
+    <TravelNavbar currentPage="main" @navigate="handleNavigation" />
 
-      <form @submit.prevent="handleSignUp" class="space-y-4">
-        <div>
-          <label for="email" class="sr-only">이메일</label>
-          <input
-            type="email"
-            id="email"
-            v-model="email"
-            placeholder="이메일"
-            required
-            class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
-          />
+    <!-- Main Content -->
+    <div class="flex min-h-screen items-center justify-center p-4">
+      <div
+        class="w-full max-w-sm rounded-xl border-2 border-[#2C2C2C] bg-white p-8 shadow-[3px_3px_0px_0px_rgba(44,44,44,0.1)]"
+      >
+        <div class="text-center">
+          <h2 class="mb-2 text-3xl font-bold text-gray-800">회원가입</h2>
+          <p class="mb-6 text-sm font-medium text-gray-500">새로운 계정을 만들어 여행을 기록하세요</p>
         </div>
 
-        <div>
-          <label for="nickname" class="sr-only">닉네임</label>
-          <input
-            type="text"
-            id="nickname"
-            v-model="nickname"
-            placeholder="닉네임"
-            required
-            class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
-          />
+        <form @submit.prevent="handleSignUp" class="space-y-4">
+          <div>
+            <label for="email" class="sr-only">이메일</label>
+            <input
+              type="email"
+              id="email"
+              v-model="email"
+              placeholder="이메일"
+              required
+              class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
+            />
+          </div>
+
+          <div>
+            <label for="nickname" class="sr-only">닉네임</label>
+            <input
+              type="text"
+              id="nickname"
+              v-model="nickname"
+              placeholder="닉네임"
+              required
+              class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
+            />
+          </div>
+
+          <div>
+            <label for="password" class="sr-only">비밀번호</label>
+            <input
+              type="password"
+              id="password"
+              v-model="password"
+              placeholder="비밀번호"
+              required
+              class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
+            />
+          </div>
+
+          <div>
+            <label for="passwordConfirm" class="sr-only">비밀번호 확인</label>
+            <input
+              type="password"
+              id="passwordConfirm"
+              v-model="passwordConfirm"
+              placeholder="비밀번호 확인"
+              required
+              class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
+              :class="{ 'border-red-500': isPasswordMismatch }"
+            />
+          </div>
+
+          <p v-if="errorMessage" class="text-xs text-red-500 text-center">{{ errorMessage }}</p>
+
+          <button
+            type="submit"
+            :disabled="isLoading || isPasswordMismatch"
+            class="flex w-full items-center justify-center rounded-lg border-2 border-[#2C2C2C] bg-[#E88555] p-3 font-black text-white transition-all hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_#2C2C2C] focus:outline-none disabled:opacity-70 disabled:hover:translate-x-0 disabled:hover:shadow-none"
+          >
+            <div
+              v-if="isLoading"
+              class="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+            ></div>
+            <span>{{ isLoading ? '가입하는 중...' : '회원가입' }}</span>
+          </button>
+        </form>
+
+        <hr class="my-6 border-gray-300" />
+
+        <div class="space-y-3 text-center text-xs font-medium text-gray-500">
+          <p>
+            계정이 이미 있는 경우에는
+            <router-link to="/login" class="font-bold text-[#E88555] hover:underline"
+              >로그인</router-link
+            >해주세요.
+          </p>
         </div>
-
-        <div>
-          <label for="password" class="sr-only">비밀번호</label>
-          <input
-            type="password"
-            id="password"
-            v-model="password"
-            placeholder="비밀번호"
-            required
-            class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
-          />
-        </div>
-
-        <div>
-          <label for="passwordConfirm" class="sr-only">비밀번호 확인</label>
-          <input
-            type="password"
-            id="passwordConfirm"
-            v-model="passwordConfirm"
-            placeholder="비밀번호 확인"
-            required
-            class="w-full rounded-lg border-2 border-[#2C2C2C] bg-white p-3 text-sm font-medium transition-all placeholder:font-medium focus:border-[#E88555] focus:outline-none focus:ring-0"
-            :class="{ 'border-red-500': isPasswordMismatch }"
-          />
-        </div>
-        
-        <p v-if="errorMessage" class="text-xs text-red-500 text-center">{{ errorMessage }}</p>
-
-        <button
-          type="submit"
-          :disabled="isLoading || isPasswordMismatch"
-          class="flex w-full items-center justify-center rounded-lg border-2 border-[#2C2C2C] bg-[#E88555] p-3 font-black text-white transition-all hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_#2C2C2C] focus:outline-none disabled:opacity-70 disabled:hover:translate-x-0 disabled:hover:shadow-none"
-        >
-          <div
-            v-if="isLoading"
-            class="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
-          ></div>
-          <span>{{ isLoading ? '가입하는 중...' : '회원가입' }}</span>
-        </button>
-      </form>
-
-      <div class="mt-6 text-center text-xs font-medium text-gray-500">
-        <a @click.prevent="goToFindAccount" href="#" class="hover:text-[#E88555] hover:underline">ID/비밀번호 찾기</a>
-        <span class="mx-2">|</span>
-        <a @click.prevent="goToLogin" href="#" class="hover:text-[#E88555] hover:underline">로그인</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### 회원가입 페이지
<img width="2542" height="1238" alt="image" src="https://github.com/user-attachments/assets/d61ea93a-9d58-488e-a388-b96cf3d58fbd" />

---

### 로그인 페이지
<img width="2539" height="1241" alt="image" src="https://github.com/user-attachments/assets/15c61102-3c46-4481-bf5b-cc7cea5a4f14" />

---

### 계정 찾기 페이지
<img width="2540" height="1240" alt="image" src="https://github.com/user-attachments/assets/a0859a41-9708-4735-a624-7f6bfa81d0da" />

---

### 🎉 예정했던 개선 사항 적용 완료

- #16 에서 언급한 `📅 향후 계획`을 실천함과 동시에 UI를 개선했습니다.