### PR TITLE
feat: 여행 계획 페이지 백엔드 API 연동 완료

### DIFF
--- a/src/apis/trip.ts
+++ b/src/apis/trip.ts
@@ -1,8 +1,8 @@
 import apiClient from '@/services/api'
 import type {
   TripDetailResponseDto,
-  TripItemAddRequestDto,
   TripItemResponseDto,
+  TripItemSyncRequestDto,
 } from '@/types/trip'
 
 // API 호출 함수
@@ -35,15 +35,15 @@ export const deleteTrip = async (tripId: number): Promise<void> => {
 }
 
 /**
- * 특정 여행 계획에 새로운 장소(아이템)를 추가합니다.
- * @param tripId 여행 계획 ID
- * @param itemData 추가할 아이템 정보
- * @returns 생성된 여행 아이템 정보
+ * 여행 아이템 목록 전체를 동기화합니다.
+ * @param tripId 동기화할 여행의 ID
+ * @param syncData 날짜별 아이템 목록
+ * @returns 변경이 완료된 전체 아이템 목록
  */
-export const addTripItem = async (
+export const syncTripItems = async (
   tripId: number,
-  itemData: TripItemAddRequestDto,
-): Promise<TripItemResponseDto> => {
-  const response = await apiClient.post<TripItemResponseDto>(`/trips/${tripId}/items`, itemData)
+  syncData: TripItemSyncRequestDto,
+): Promise<TripItemResponseDto[]> => {
+  const response = await apiClient.put<TripItemResponseDto[]>(`/trips/${tripId}/items`, syncData)
   return response.data
 }

--- a/src/apis/trip.ts
+++ b/src/apis/trip.ts
@@ -21,3 +21,11 @@ export const getTripDetail = async (tripId: number): Promise<TripDetailResponseD
   const response = await apiClient.get<TripDetailResponseDto>(`/trips/${tripId}`)
   return response.data
 }
+
+/**
+ * 특정 여행 계획을 삭제합니다.
+ * @param tripId 삭제할 여행 계획의 ID
+ */
+export const deleteTrip = async (tripId: number): Promise<void> => {
+  await apiClient.delete(`/trips/${tripId}`)
+}

--- a/src/apis/trip.ts
+++ b/src/apis/trip.ts
@@ -1,0 +1,23 @@
+import apiClient from '@/services/api'
+import type { TripDetailResponseDto } from '@/types/trip'
+
+// API 호출 함수
+/**
+ * 새로운 빈 여행 계획을 생성합니다.
+ * '여행 계획 시작' 시점에 호출됩니다.
+ * @returns 생성된 여행의 상세 정보 (TripDetailResponseDto)
+ */
+export const createTrip = async (): Promise<TripDetailResponseDto> => {
+  const response = await apiClient.post<TripDetailResponseDto>('/trips')
+  return response.data
+}
+
+/**
+ * 특정 여행 계획의 상세 정보를 조회합니다.
+ * @param tripId 조회할 여행 계획의 ID
+ * @returns 여행 계획의 상세 정보 (TripDetailResponseDto)
+ */
+export const getTripDetail = async (tripId: number): Promise<TripDetailResponseDto> => {
+  const response = await apiClient.get<TripDetailResponseDto>(`/trips/${tripId}`)
+  return response.data
+}

--- a/src/apis/trip.ts
+++ b/src/apis/trip.ts
@@ -1,5 +1,9 @@
 import apiClient from '@/services/api'
-import type { TripDetailResponseDto } from '@/types/trip'
+import type {
+  TripDetailResponseDto,
+  TripItemAddRequestDto,
+  TripItemResponseDto,
+} from '@/types/trip'
 
 // API 호출 함수
 /**
@@ -28,4 +32,18 @@ export const getTripDetail = async (tripId: number): Promise<TripDetailResponseD
  */
 export const deleteTrip = async (tripId: number): Promise<void> => {
   await apiClient.delete(`/trips/${tripId}`)
+}
+
+/**
+ * 특정 여행 계획에 새로운 장소(아이템)를 추가합니다.
+ * @param tripId 여행 계획 ID
+ * @param itemData 추가할 아이템 정보
+ * @returns 생성된 여행 아이템 정보
+ */
+export const addTripItem = async (
+  tripId: number,
+  itemData: TripItemAddRequestDto,
+): Promise<TripItemResponseDto> => {
+  const response = await apiClient.post<TripItemResponseDto>(`/trips/${tripId}/items`, itemData)
+  return response.data
 }

--- a/src/apis/trip.ts
+++ b/src/apis/trip.ts
@@ -3,6 +3,7 @@ import type {
   TripDetailResponseDto,
   TripItemResponseDto,
   TripItemSyncRequestDto,
+  TripUpdateRequestDto,
 } from '@/types/trip'
 
 // API 호출 함수
@@ -45,5 +46,19 @@ export const syncTripItems = async (
   syncData: TripItemSyncRequestDto,
 ): Promise<TripItemResponseDto[]> => {
   const response = await apiClient.put<TripItemResponseDto[]>(`/trips/${tripId}/items`, syncData)
+  return response.data
+}
+
+/**
+ * 여행의 기본 정보(제목, 날짜, 상태, 공개 여부)를 수정합니다.
+ * @param tripId 수정할 여행의 ID
+ * @param updateData 수정할 여행 정보
+ * @returns 수정된 여행의 상세 정보 (TripDetailResponseDto)
+ */
+export const updateTrip = async (
+  tripId: number,
+  updateData: TripUpdateRequestDto,
+): Promise<TripDetailResponseDto> => {
+  const response = await apiClient.put<TripDetailResponseDto>(`/trips/${tripId}`, updateData)
   return response.data
 }

--- a/src/components/trip/TripPlanPanel.vue
+++ b/src/components/trip/TripPlanPanel.vue
@@ -88,7 +88,7 @@
 
               <button
                 v-if="isEditMode"
-                @click="$emit('remove-place', place.id)"
+                @click.stop="$emit('remove-place', place)"
                 class="w-4 h-4 bg-red-50 border-[1px] border-red-300 rounded hover:bg-red-100 flex items-center justify-center transition-colors flex-shrink-0"
               >
                 <X class="w-2.5 h-2.5 text-red-600" stroke-width="2.5" />
@@ -132,7 +132,7 @@ defineEmits<{
   (e: 'update:searchQuery', val: string): void
   (e: 'update:activeDay', val: number): void
   (e: 'search'): void
-  (e: 'remove-place', placeId: number): void
+  (e: 'remove-place', place: Place): void
   (e: 'add-day'): void
   (e: 'remove-day', dayNum: number): void
   (e: 'update-places', newPlaces: Place[]): void

--- a/src/composables/trip/usePlaceSearch.ts
+++ b/src/composables/trip/usePlaceSearch.ts
@@ -36,6 +36,7 @@ export function usePlaceSearch() {
         if (status === (window as any).kakao.maps.services.Status.OK) {
           searchResults.value = data.map((item: any) => ({
             id: Number(item.id),
+            kakaoPlaceId: item.id, // 카카오 ID를 문자열로 저장
             name: item.place_name,
             address: item.road_address_name || item.address_name,
             category: item.category_group_name || '기타',

--- a/src/composables/trip/useTripPlan.ts
+++ b/src/composables/trip/useTripPlan.ts
@@ -1,16 +1,35 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import type { Place, TripDetailResponseDto, TripItemAddRequestDto } from '@/types/trip'
+import type {
+  Place,
+  TripDetailResponseDto,
+  TripItemSyncRequestDto,
+  ItemSyncDto,
+  TripItemResponseDto,
+} from '@/types/trip'
 import {
   getTripDetail,
   deleteTrip as apiDeleteTrip,
-  addTripItem as apiAddTripItem,
+  syncTripItems as apiSyncTripItems,
 } from '@/services/trip'
 
 export interface DayPlan {
   dayNumber: number
   places: Place[]
 }
+
+// API 응답을 프론트엔드 Place 타입으로 변환하는 헬퍼 함수
+const mapTripItemToPlace = (item: TripItemResponseDto): Place => ({
+  id: item.id,
+  kakaoPlaceId: item.spot.kakaoPlaceId,
+  name: item.spot.name,
+  address: item.spot.address,
+  category: item.spot.category,
+  lat: item.spot.lat,
+  lng: item.spot.lng,
+  url: item.spot.placeUrl,
+  memo: item.memo,
+})
 
 export function useTripPlan() {
   const route = useRoute()
@@ -33,61 +52,43 @@ export function useTripPlan() {
   const allSelectedPlaces = computed(() => days.value.flatMap((d) => d.places))
 
   // Methods
-  const initData = async () => {
-    // 'create-trip' 경로로 직접 접근 시, 새 여행 생성을 TripView에서 처리하므로 로직을 단순화합니다.
-    // 이 경로는 현재 사용되지 않을 것으로 예상되지만, 방어적으로 남겨둡니다.
-    if (route.name === 'create-trip') {
-      tripTitle.value = ''
-      tripDate.value = new Date().toISOString().split('T')[0]
-      days.value = [{ dayNumber: 1, places: [] }]
-      isEditMode.value = true
-      tripStatus.value = 'DRAFT' // 새 여행이므로 DRAFT로 설정
-      return
-    }
+  const reloadTripData = async () => {
+    if (!tripId.value) return
+    try {
+      const tripDetail = await getTripDetail(tripId.value)
+      tripTitle.value = tripDetail.title
+      tripDate.value = tripDetail.startDate || ''
+      tripStatus.value = tripDetail.status
 
+      // API 응답을 로컬 상태로 변환
+      const maxDay = tripDetail.tripItems.reduce((max, item) => Math.max(max, item.dayNumber), 0)
+      const newDays: DayPlan[] = []
+      for (let i = 1; i <= maxDay; i++) {
+        newDays.push({
+          dayNumber: i,
+          places: tripDetail.tripItems
+            .filter((item) => item.dayNumber === i)
+            .sort((a, b) => a.orderIndex - b.orderIndex)
+            .filter((item) => item && item.spot) // item 및 item.spot null 체크
+            .map(mapTripItemToPlace),
+        })
+      }
+      days.value = newDays.length > 0 ? newDays : [{ dayNumber: 1, places: [] }]
+    } catch (error) {
+      console.error(`여행 계획 (ID: ${tripId.value}) 상세 정보 불러오기 실패:`, error)
+      alert('여행 계획 상세 정보를 불러오는데 실패했습니다.')
+      router.push('/trips')
+    }
+  }
+
+  const initData = async () => {
     if (route.name === 'trip-detail' && route.params.id) {
       tripId.value = Number(route.params.id)
-      try {
-        const tripDetail = await getTripDetail(tripId.value)
-        tripTitle.value = tripDetail.title
-        tripDate.value = tripDetail.startDate || ''
-        tripStatus.value = tripDetail.status
-        isEditMode.value = true // 상세 페이지 진입 시 항상 편집 모드
+      await reloadTripData()
 
-        // 백업 데이터는 PUBLIC 상태의 여행을 편집 시작할 때만 생성
-        if (tripDetail.status === 'PUBLIC') {
-          enterEditMode()
-        }
-
-        // API에서 받은 tripItems를 DayPlan[] 형태로 변환
-        const maxDay = tripDetail.tripItems.reduce((max, item) => Math.max(max, item.dayNumber), 0)
-        const newDays: DayPlan[] = []
-        for (let i = 1; i <= maxDay; i++) {
-          newDays.push({
-            dayNumber: i,
-            places: tripDetail.tripItems
-              .filter((item) => item.dayNumber === i)
-              .sort((a, b) => a.orderIndex - b.orderIndex)
-              .map(
-                (item) =>
-                  ({
-                    id: item.id,
-                    kakaoPlaceId: item.spot.kakaoPlaceId, // kakaoPlaceId 추가
-                    name: item.spot.name,
-                    address: item.spot.address,
-                    category: item.spot.category,
-                    lat: item.spot.lat,
-                    lng: item.spot.lng,
-                    url: item.spot.placeUrl,
-                  } as Place),
-              ),
-          })
-        }
-        days.value = newDays.length > 0 ? newDays : [{ dayNumber: 1, places: [] }]
-      } catch (error) {
-        console.error(`여행 계획 (ID: ${tripId.value}) 상세 정보 불러오기 실패:`, error)
-        alert('여행 계획 상세 정보를 불러오는데 실패했습니다.')
-        router.push('/trips')
+      isEditMode.value = true
+      if (tripStatus.value === 'PUBLIC') {
+        enterEditMode()
       }
     }
   }
@@ -102,19 +103,58 @@ export function useTripPlan() {
   }
 
   const saveTrip = async (callback?: () => void) => {
+    if (!tripId.value) return alert('여행 정보가 올바르게 로드되지 않았습니다.')
     if (!tripTitle.value.trim()) return alert('제목을 입력해주세요.')
-    // TODO: PUT /api/trips/{tripId} API 연동 필요
-    await new Promise((r) => setTimeout(r, 200))
-    alert('저장되었습니다!')
-    tripStatus.value = 'PUBLIC' // 저장 후 상태를 PUBLIC으로 변경
-    isEditMode.value = false
-    if (callback) callback()
+
+    try {
+      const payload: TripItemSyncRequestDto = {
+        days: days.value.map((day) => ({
+          dayNumber: day.dayNumber,
+          items: day.places.map((place): ItemSyncDto => {
+            // id가 있는 장소는 기존 아이템
+            if (place.id) {
+              return { tripItemId: place.id, memo: place.memo }
+            }
+            // id가 없는 장소는 신규 아이템
+            else {
+              return {
+                spot: {
+                  kakaoPlaceId: place.kakaoPlaceId,
+                  name: place.name,
+                  address: place.address,
+                  category: place.category,
+                  lat: place.lat,
+                  lng: place.lng,
+                  placeUrl: place.url || '',
+                },
+                memo: place.memo,
+              }
+            }
+          }),
+        })),
+      }
+
+      await apiSyncTripItems(tripId.value, payload)
+
+      // 데이터를 다시 로드하여 UI를 동기화합니다.
+      await reloadTripData()
+
+      // TODO: 여행 정보(제목, 날짜 등) 수정 API 호출
+      // PUT /api/trips/{tripId}
+
+      alert('저장되었습니다!')
+      tripStatus.value = 'PUBLIC'
+      isEditMode.value = false
+      if (callback) callback()
+    } catch (error) {
+      console.error('여행 계획 저장 실패:', error)
+      alert('저장에 실패했습니다. 다시 시도해주세요.')
+    }
   }
 
   const goBack = async (callback?: () => void) => {
     if (isEditMode.value) {
       if (confirm('작성을 취소하시겠습니까? 변경사항이 저장되지 않습니다.')) {
-        // DRAFT 상태의 여행 계획(새로 생성된 계획)을 취소할 경우 삭제 API 호출
         if (tripStatus.value === 'DRAFT' && tripId.value) {
           try {
             await apiDeleteTrip(tripId.value)
@@ -124,7 +164,6 @@ export function useTripPlan() {
             alert('임시 여행 계획 삭제에 실패했습니다.')
           }
         } else if (backupData.value) {
-          // PUBLIC 상태의 여행 계획 편집을 취소할 경우, 백업 데이터로 복원
           const restored = JSON.parse(backupData.value)
           tripTitle.value = restored.title
           tripDate.value = restored.date
@@ -132,7 +171,6 @@ export function useTripPlan() {
           isEditMode.value = false
           if (callback) callback()
         } else {
-          // 백업 데이터가 없는 경우 (예: DRAFT 상태에서 새로고침 후 취소)는 목록으로 이동
           router.push('/trips')
         }
       }
@@ -154,64 +192,37 @@ export function useTripPlan() {
     }
   }
 
-  // 일정 관리 (Place CRUD)
-  const addPlace = async (place: Place) => {
-    if (!tripId.value) {
-      alert('여행 계획이 올바르게 로드되지 않았습니다.')
-      return
-    }
+  // --- 로컬 상태 변경 함수들 ---
 
+  const addPlace = (place: Place) => {
     const day = days.value.find((d) => d.dayNumber === activeDay.value)
-    if (!day) {
-      alert('유효하지 않은 일차입니다.')
-      return
-    }
+    if (!day) return alert('유효하지 않은 일차입니다.')
 
-    // 카카오 장소 ID로 중복 체크
     const isDuplicate = day.places.some((p) => p.kakaoPlaceId === place.kakaoPlaceId)
-    if (isDuplicate) {
-      alert('이미 추가된 장소입니다.')
-      return
-    }
+    if (isDuplicate) return alert('이미 추가된 장소입니다.')
 
-    try {
-      const itemData: TripItemAddRequestDto = {
-        dayNumber: activeDay.value,
-        orderIndex: day.places.length,
-        spot: {
-          kakaoPlaceId: place.kakaoPlaceId,
-          name: place.name,
-          address: place.address,
-          category: place.category,
-          lat: place.lat,
-          lng: place.lng,
-          placeUrl: place.url || '',
-        },
-      }
-
-      const newItem = await apiAddTripItem(tripId.value, itemData)
-
-      // API 호출 성공 후 UI에 반영
-      // 중요: 백엔드에서 받은 tripItemId를 프론트엔드 Place 객체의 id로 사용
-      const newPlace: Place = {
-        ...place,
-        id: newItem.id,
-      }
-      day.places.push(newPlace)
-    } catch (error) {
-      console.error('장소 추가 실패:', error)
-      alert('장소 추가에 실패했습니다. 다시 시도해주세요.')
-    }
+    // id 없이 로컬에만 추가
+    day.places.push({ ...place, id: undefined, memo: '' })
   }
 
-  const removePlace = (id: number) => {
+  const removePlace = (placeToRemove: Place) => {
     const day = days.value.find((d) => d.dayNumber === activeDay.value)
-    if (day) day.places = day.places.filter((p) => p.id !== id)
+    if (day) {
+      day.places = day.places.filter((p) => {
+        // id가 있으면 id로, 없으면 kakaoPlaceId로 비교하여 삭제
+        if (p.id && placeToRemove.id) {
+          return p.id !== placeToRemove.id
+        }
+        return p.kakaoPlaceId !== placeToRemove.kakaoPlaceId
+      })
+    }
   }
 
   const updatePlaces = (newPlaces: Place[]) => {
     const day = days.value.find((d) => d.dayNumber === activeDay.value)
-    if (day) day.places = newPlaces
+    if (day) {
+      day.places = newPlaces
+    }
   }
 
   const addDay = () => {
@@ -221,10 +232,12 @@ export function useTripPlan() {
 
   const removeDay = (dayNum: number) => {
     if (days.value.length <= 1) return
-    if (confirm('일차를 삭제하시겠습니까?')) {
-      days.value = days.value
-        .filter((d) => d.dayNumber !== dayNum)
-        .map((d, i) => ({ ...d, dayNumber: i + 1 }))
+    if (confirm('일차를 삭제하시겠습니까? 해당 일차의 모든 장소가 삭제됩니다.')) {
+      days.value = days.value.filter((d) => d.dayNumber !== dayNum)
+      // 남은 day들의 dayNumber를 재정렬
+      days.value.forEach((day, index) => {
+        day.dayNumber = index + 1
+      })
       if (activeDay.value >= dayNum && activeDay.value > 1) {
         activeDay.value--
       }

--- a/src/composables/trip/useTripPlan.ts
+++ b/src/composables/trip/useTripPlan.ts
@@ -2,15 +2,18 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import type {
   Place,
-  TripDetailResponseDto,
   TripItemSyncRequestDto,
   ItemSyncDto,
   TripItemResponseDto,
+  TripStatus,
+  TripVisibility,
+  TripUpdateRequestDto,
 } from '@/types/trip'
 import {
   getTripDetail,
   deleteTrip as apiDeleteTrip,
   syncTripItems as apiSyncTripItems,
+  updateTrip as apiUpdateTrip,
 } from '@/services/trip'
 
 export interface DayPlan {
@@ -35,7 +38,8 @@ export function useTripPlan() {
   const route = useRoute()
   const router = useRouter()
   const tripId = ref<number | null>(null)
-  const tripStatus = ref<TripDetailResponseDto['status'] | null>(null)
+  const tripStatus = ref<TripStatus | null>(null)
+  const tripVisibility = ref<TripVisibility | null>(null)
 
   // State
   const isEditMode = ref(false)
@@ -59,6 +63,7 @@ export function useTripPlan() {
       tripTitle.value = tripDetail.title
       tripDate.value = tripDetail.startDate || ''
       tripStatus.value = tripDetail.status
+      tripVisibility.value = tripDetail.visibility
 
       // API 응답을 로컬 상태로 변환
       const maxDay = tripDetail.tripItems.reduce((max, item) => Math.max(max, item.dayNumber), 0)
@@ -87,7 +92,8 @@ export function useTripPlan() {
       await reloadTripData()
 
       isEditMode.value = true
-      if (tripStatus.value === 'PUBLIC') {
+      if (tripVisibility.value === 'PUBLIC') {
+        // Changed from tripStatus to tripVisibility
         enterEditMode()
       }
     }
@@ -107,16 +113,14 @@ export function useTripPlan() {
     if (!tripTitle.value.trim()) return alert('제목을 입력해주세요.')
 
     try {
-      const payload: TripItemSyncRequestDto = {
+      // 1. 여행 아이템 동기화
+      const itemPayload: TripItemSyncRequestDto = {
         days: days.value.map((day) => ({
           dayNumber: day.dayNumber,
           items: day.places.map((place): ItemSyncDto => {
-            // id가 있는 장소는 기존 아이템
             if (place.id) {
               return { tripItemId: place.id, memo: place.memo }
-            }
-            // id가 없는 장소는 신규 아이템
-            else {
+            } else {
               return {
                 spot: {
                   kakaoPlaceId: place.kakaoPlaceId,
@@ -133,17 +137,22 @@ export function useTripPlan() {
           }),
         })),
       }
+      await apiSyncTripItems(tripId.value, itemPayload)
 
-      await apiSyncTripItems(tripId.value, payload)
+      // 2. 여행 기본 정보 (제목, 날짜, 상태, 공개 여부) 업데이트
+      const updatePayload: TripUpdateRequestDto = {
+        title: tripTitle.value,
+        startDate: tripDate.value || undefined,
+        endDate: undefined, // Assuming endDate is not managed by frontend yet
+        status: 'PLANNED', // User wants to save as PLANNED
+        visibility: 'PUBLIC', // User wants to save as PUBLIC
+      }
+      await apiUpdateTrip(tripId.value, updatePayload)
 
-      // 데이터를 다시 로드하여 UI를 동기화합니다.
+      // 3. 데이터를 다시 로드하여 UI를 동기화합니다.
       await reloadTripData()
 
-      // TODO: 여행 정보(제목, 날짜 등) 수정 API 호출
-      // PUT /api/trips/{tripId}
-
       alert('저장되었습니다!')
-      tripStatus.value = 'PUBLIC'
       isEditMode.value = false
       if (callback) callback()
     } catch (error) {
@@ -264,5 +273,6 @@ export function useTripPlan() {
     updatePlaces,
     addDay,
     removeDay,
+    tripVisibility,
   }
 }

--- a/src/composables/trip/useTripPlan.ts
+++ b/src/composables/trip/useTripPlan.ts
@@ -1,7 +1,11 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import type { Place, TripDetailResponseDto } from '@/types/trip'
-import { getTripDetail, deleteTrip as apiDeleteTrip } from '@/services/trip'
+import type { Place, TripDetailResponseDto, TripItemAddRequestDto } from '@/types/trip'
+import {
+  getTripDetail,
+  deleteTrip as apiDeleteTrip,
+  addTripItem as apiAddTripItem,
+} from '@/services/trip'
 
 export interface DayPlan {
   dayNumber: number
@@ -64,15 +68,19 @@ export function useTripPlan() {
             places: tripDetail.tripItems
               .filter((item) => item.dayNumber === i)
               .sort((a, b) => a.orderIndex - b.orderIndex)
-              .map((item) => ({
-                id: item.id,
-                name: item.spot.name,
-                address: item.spot.address,
-                category: item.spot.category,
-                lat: item.spot.lat,
-                lng: item.spot.lng,
-                url: item.spot.placeUrl,
-              })),
+              .map(
+                (item) =>
+                  ({
+                    id: item.id,
+                    kakaoPlaceId: item.spot.kakaoPlaceId, // kakaoPlaceId 추가
+                    name: item.spot.name,
+                    address: item.spot.address,
+                    category: item.spot.category,
+                    lat: item.spot.lat,
+                    lng: item.spot.lng,
+                    url: item.spot.placeUrl,
+                  } as Place),
+              ),
           })
         }
         days.value = newDays.length > 0 ? newDays : [{ dayNumber: 1, places: [] }]
@@ -146,13 +154,53 @@ export function useTripPlan() {
     }
   }
 
-  // ... (일정 관리 메서드들은 동일)
-  const addPlace = (place: Place) => {
+  // 일정 관리 (Place CRUD)
+  const addPlace = async (place: Place) => {
+    if (!tripId.value) {
+      alert('여행 계획이 올바르게 로드되지 않았습니다.')
+      return
+    }
+
     const day = days.value.find((d) => d.dayNumber === activeDay.value)
-    if (day && !day.places.find((p) => p.id === place.id)) {
-      day.places.push({ ...place })
-    } else {
+    if (!day) {
+      alert('유효하지 않은 일차입니다.')
+      return
+    }
+
+    // 카카오 장소 ID로 중복 체크
+    const isDuplicate = day.places.some((p) => p.kakaoPlaceId === place.kakaoPlaceId)
+    if (isDuplicate) {
       alert('이미 추가된 장소입니다.')
+      return
+    }
+
+    try {
+      const itemData: TripItemAddRequestDto = {
+        dayNumber: activeDay.value,
+        orderIndex: day.places.length,
+        spot: {
+          kakaoPlaceId: place.kakaoPlaceId,
+          name: place.name,
+          address: place.address,
+          category: place.category,
+          lat: place.lat,
+          lng: place.lng,
+          placeUrl: place.url || '',
+        },
+      }
+
+      const newItem = await apiAddTripItem(tripId.value, itemData)
+
+      // API 호출 성공 후 UI에 반영
+      // 중요: 백엔드에서 받은 tripItemId를 프론트엔드 Place 객체의 id로 사용
+      const newPlace: Place = {
+        ...place,
+        id: newItem.id,
+      }
+      day.places.push(newPlace)
+    } catch (error) {
+      console.error('장소 추가 실패:', error)
+      alert('장소 추가에 실패했습니다. 다시 시도해주세요.')
     }
   }
 

--- a/src/composables/trip/useTripPlan.ts
+++ b/src/composables/trip/useTripPlan.ts
@@ -1,7 +1,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import type { Place } from '@/types/trip'
-import { getTripDetail } from '@/services/trip'
+import type { Place, TripDetailResponseDto } from '@/types/trip'
+import { getTripDetail, deleteTrip as apiDeleteTrip } from '@/services/trip'
 
 export interface DayPlan {
   dayNumber: number
@@ -11,11 +11,11 @@ export interface DayPlan {
 export function useTripPlan() {
   const route = useRoute()
   const router = useRouter()
-  const tripId = ref<number | null>(null) // tripId 상태 추가
-  const isCreating = computed(() => route.name === 'create-trip') // isCreating을 computed로 변경
+  const tripId = ref<number | null>(null)
+  const tripStatus = ref<TripDetailResponseDto['status'] | null>(null)
 
   // State
-  const isEditMode = ref(false) // 초기값 false로 변경
+  const isEditMode = ref(false)
   const backupData = ref('')
   const tripTitle = ref('')
   const tripDate = ref('')
@@ -30,63 +30,57 @@ export function useTripPlan() {
 
   // Methods
   const initData = async () => {
-    if (route.name === 'trip-detail') {
-      // 기존 여행 계획 상세 조회 및 편집 모드 진입
-      tripId.value = Number(route.params.id)
-      try {
-        const tripDetail = await getTripDetail(tripId.value)
-        tripTitle.value = tripDetail.title
-        tripDate.value = tripDetail.startDate || '' // startDate가 없으면 빈 문자열로 설정
-        // tripItems를 days 형태로 변환 (현재는 dayNumber가 1로 고정되어 있다고 가정)
-        // TODO: 실제 tripItems의 dayNumber에 따라 days 배열을 구성하는 로직 필요
-        days.value = [
-          {
-            dayNumber: 1,
-            places: tripDetail.tripItems.map((item) => ({
-              id: item.id, // tripItemId를 id로 변경
-              name: item.spot.name,
-              address: item.spot.address,
-              category: item.spot.category,
-              lat: item.spot.lat,
-              lng: item.spot.lng,
-              phone: undefined, // API 응답에 phone이 없으므로 undefined
-              url: item.spot.placeUrl,
-            })),
-          },
-        ]
-        isEditMode.value = true // 편집 모드로 바로 진입
-      } catch (error) {
-        console.error(`여행 계획 (ID: ${tripId.value}) 상세 정보 불러오기 실패:`, error)
-        alert('여행 계획 상세 정보를 불러오는데 실패했습니다.')
-        router.push('/trips') // 실패 시 목록 페이지로 리다이렉트
-      }
-    } else if (isCreating.value) {
-      // /create-trip 경로로 직접 접근한 경우 (현재는 TripView에서 생성 후 이동하므로 이 경로는 사용되지 않을 수 있음)
+    // 'create-trip' 경로로 직접 접근 시, 새 여행 생성을 TripView에서 처리하므로 로직을 단순화합니다.
+    // 이 경로는 현재 사용되지 않을 것으로 예상되지만, 방어적으로 남겨둡니다.
+    if (route.name === 'create-trip') {
       tripTitle.value = ''
       tripDate.value = new Date().toISOString().split('T')[0]
       days.value = [{ dayNumber: 1, places: [] }]
       isEditMode.value = true
-    } else {
-      // Mock Data Load (나중에 API로 대체될 부분)
-      tripTitle.value = '성수동 핫플 투어 🔥'
-      tripDate.value = '2024-12-25'
-      days.value = [
-        {
-          dayNumber: 1,
-          places: [
-            {
-              id: 1,
-              name: '대림창고',
-              address: '서울시 성동구...',
-              category: '카페',
-              lat: 37.5443,
-              lng: 127.0557,
-            },
-          ],
-        },
-      ]
-      if (route.query.edit === 'true') enterEditMode()
-      else isEditMode.value = false
+      tripStatus.value = 'DRAFT' // 새 여행이므로 DRAFT로 설정
+      return
+    }
+
+    if (route.name === 'trip-detail' && route.params.id) {
+      tripId.value = Number(route.params.id)
+      try {
+        const tripDetail = await getTripDetail(tripId.value)
+        tripTitle.value = tripDetail.title
+        tripDate.value = tripDetail.startDate || ''
+        tripStatus.value = tripDetail.status
+        isEditMode.value = true // 상세 페이지 진입 시 항상 편집 모드
+
+        // 백업 데이터는 PUBLIC 상태의 여행을 편집 시작할 때만 생성
+        if (tripDetail.status === 'PUBLIC') {
+          enterEditMode()
+        }
+
+        // API에서 받은 tripItems를 DayPlan[] 형태로 변환
+        const maxDay = tripDetail.tripItems.reduce((max, item) => Math.max(max, item.dayNumber), 0)
+        const newDays: DayPlan[] = []
+        for (let i = 1; i <= maxDay; i++) {
+          newDays.push({
+            dayNumber: i,
+            places: tripDetail.tripItems
+              .filter((item) => item.dayNumber === i)
+              .sort((a, b) => a.orderIndex - b.orderIndex)
+              .map((item) => ({
+                id: item.id,
+                name: item.spot.name,
+                address: item.spot.address,
+                category: item.spot.category,
+                lat: item.spot.lat,
+                lng: item.spot.lng,
+                url: item.spot.placeUrl,
+              })),
+          })
+        }
+        days.value = newDays.length > 0 ? newDays : [{ dayNumber: 1, places: [] }]
+      } catch (error) {
+        console.error(`여행 계획 (ID: ${tripId.value}) 상세 정보 불러오기 실패:`, error)
+        alert('여행 계획 상세 정보를 불러오는데 실패했습니다.')
+        router.push('/trips')
+      }
     }
   }
 
@@ -101,25 +95,37 @@ export function useTripPlan() {
 
   const saveTrip = async (callback?: () => void) => {
     if (!tripTitle.value.trim()) return alert('제목을 입력해주세요.')
-
-    // 이제 여행 계획 생성은 TripView에서 처리하므로, 여기서는 항상 수정 모드로 간주합니다.
+    // TODO: PUT /api/trips/{tripId} API 연동 필요
     await new Promise((r) => setTimeout(r, 200))
     alert('저장되었습니다!')
+    tripStatus.value = 'PUBLIC' // 저장 후 상태를 PUBLIC으로 변경
     isEditMode.value = false
     if (callback) callback()
   }
 
-  const goBack = (callback?: () => void) => {
+  const goBack = async (callback?: () => void) => {
     if (isEditMode.value) {
-      if (confirm('취소하시겠습니까?')) {
-        if (isCreating.value) router.push('/trips')
-        else {
+      if (confirm('작성을 취소하시겠습니까? 변경사항이 저장되지 않습니다.')) {
+        // DRAFT 상태의 여행 계획(새로 생성된 계획)을 취소할 경우 삭제 API 호출
+        if (tripStatus.value === 'DRAFT' && tripId.value) {
+          try {
+            await apiDeleteTrip(tripId.value)
+            router.push('/trips')
+          } catch (error) {
+            console.error(`여행 계획 (ID: ${tripId.value}) 삭제 실패:`, error)
+            alert('임시 여행 계획 삭제에 실패했습니다.')
+          }
+        } else if (backupData.value) {
+          // PUBLIC 상태의 여행 계획 편집을 취소할 경우, 백업 데이터로 복원
           const restored = JSON.parse(backupData.value)
           tripTitle.value = restored.title
           tripDate.value = restored.date
           days.value = restored.days
           isEditMode.value = false
           if (callback) callback()
+        } else {
+          // 백업 데이터가 없는 경우 (예: DRAFT 상태에서 새로고침 후 취소)는 목록으로 이동
+          router.push('/trips')
         }
       }
     } else {
@@ -127,17 +133,23 @@ export function useTripPlan() {
     }
   }
 
-  const deleteTrip = () => {
-    if (confirm('정말 삭제하시겠습니까?')) {
-      alert('삭제되었습니다.')
-      router.push('/trips')
+  const deleteTrip = async () => {
+    if (tripId.value && confirm('정말 삭제하시겠습니까?')) {
+      try {
+        await apiDeleteTrip(tripId.value)
+        alert('삭제되었습니다.')
+        router.push('/trips')
+      } catch (error) {
+        console.error(`여행 계획 (ID: ${tripId.value}) 삭제 실패:`, error)
+        alert('여행 계획 삭제에 실패했습니다.')
+      }
     }
   }
 
-  // 일정 관리 (Place CRUD)
+  // ... (일정 관리 메서드들은 동일)
   const addPlace = (place: Place) => {
     const day = days.value.find((d) => d.dayNumber === activeDay.value)
-    if (day && !day.places.find((p) => p.name === place.name)) {
+    if (day && !day.places.find((p) => p.id === place.id)) {
       day.places.push({ ...place })
     } else {
       alert('이미 추가된 장소입니다.')
@@ -161,18 +173,20 @@ export function useTripPlan() {
 
   const removeDay = (dayNum: number) => {
     if (days.value.length <= 1) return
-    if (confirm('삭제하시겠습니까?')) {
+    if (confirm('일차를 삭제하시겠습니까?')) {
       days.value = days.value
         .filter((d) => d.dayNumber !== dayNum)
         .map((d, i) => ({ ...d, dayNumber: i + 1 }))
-      if (activeDay.value > 1) activeDay.value--
+      if (activeDay.value >= dayNum && activeDay.value > 1) {
+        activeDay.value--
+      }
     }
   }
 
   onMounted(() => initData())
 
   return {
-    tripId, // tripId 반환
+    tripId,
     isEditMode,
     tripTitle,
     tripDate,

--- a/src/composables/trip/useTripPlan.ts
+++ b/src/composables/trip/useTripPlan.ts
@@ -1,6 +1,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import type { Place } from './usePlaceSearch'
+import type { Place } from '@/types/trip'
+import { getTripDetail } from '@/services/trip'
 
 export interface DayPlan {
   dayNumber: number
@@ -10,10 +11,11 @@ export interface DayPlan {
 export function useTripPlan() {
   const route = useRoute()
   const router = useRouter()
-  const isCreating = route.name === 'create-trip'
+  const tripId = ref<number | null>(null) // tripId 상태 추가
+  const isCreating = computed(() => route.name === 'create-trip') // isCreating을 computed로 변경
 
   // State
-  const isEditMode = ref(isCreating)
+  const isEditMode = ref(false) // 초기값 false로 변경
   const backupData = ref('')
   const tripTitle = ref('')
   const tripDate = ref('')
@@ -28,7 +30,38 @@ export function useTripPlan() {
 
   // Methods
   const initData = async () => {
-    if (isCreating) {
+    if (route.name === 'trip-detail') {
+      // 기존 여행 계획 상세 조회 및 편집 모드 진입
+      tripId.value = Number(route.params.id)
+      try {
+        const tripDetail = await getTripDetail(tripId.value)
+        tripTitle.value = tripDetail.title
+        tripDate.value = tripDetail.startDate || '' // startDate가 없으면 빈 문자열로 설정
+        // tripItems를 days 형태로 변환 (현재는 dayNumber가 1로 고정되어 있다고 가정)
+        // TODO: 실제 tripItems의 dayNumber에 따라 days 배열을 구성하는 로직 필요
+        days.value = [
+          {
+            dayNumber: 1,
+            places: tripDetail.tripItems.map((item) => ({
+              id: item.id, // tripItemId를 id로 변경
+              name: item.spot.name,
+              address: item.spot.address,
+              category: item.spot.category,
+              lat: item.spot.lat,
+              lng: item.spot.lng,
+              phone: undefined, // API 응답에 phone이 없으므로 undefined
+              url: item.spot.placeUrl,
+            })),
+          },
+        ]
+        isEditMode.value = true // 편집 모드로 바로 진입
+      } catch (error) {
+        console.error(`여행 계획 (ID: ${tripId.value}) 상세 정보 불러오기 실패:`, error)
+        alert('여행 계획 상세 정보를 불러오는데 실패했습니다.')
+        router.push('/trips') // 실패 시 목록 페이지로 리다이렉트
+      }
+    } else if (isCreating.value) {
+      // /create-trip 경로로 직접 접근한 경우 (현재는 TripView에서 생성 후 이동하므로 이 경로는 사용되지 않을 수 있음)
       tripTitle.value = ''
       tripDate.value = new Date().toISOString().split('T')[0]
       days.value = [{ dayNumber: 1, places: [] }]
@@ -68,6 +101,8 @@ export function useTripPlan() {
 
   const saveTrip = async (callback?: () => void) => {
     if (!tripTitle.value.trim()) return alert('제목을 입력해주세요.')
+
+    // 이제 여행 계획 생성은 TripView에서 처리하므로, 여기서는 항상 수정 모드로 간주합니다.
     await new Promise((r) => setTimeout(r, 200))
     alert('저장되었습니다!')
     isEditMode.value = false
@@ -77,7 +112,7 @@ export function useTripPlan() {
   const goBack = (callback?: () => void) => {
     if (isEditMode.value) {
       if (confirm('취소하시겠습니까?')) {
-        if (isCreating) router.push('/trips')
+        if (isCreating.value) router.push('/trips')
         else {
           const restored = JSON.parse(backupData.value)
           tripTitle.value = restored.title
@@ -137,6 +172,7 @@ export function useTripPlan() {
   onMounted(() => initData())
 
   return {
+    tripId, // tripId 반환
     isEditMode,
     tripTitle,
     tripDate,

--- a/src/services/trip.ts
+++ b/src/services/trip.ts
@@ -2,8 +2,13 @@ import {
   createTrip as apiCreateTrip,
   getTripDetail as apiGetTripDetail,
   deleteTrip as apiDeleteTrip,
+  addTripItem as apiAddTripItem,
 } from '@/apis/trip'
-import type { TripDetailResponseDto } from '@/types/trip'
+import type {
+  TripDetailResponseDto,
+  TripItemAddRequestDto,
+  TripItemResponseDto,
+} from '@/types/trip'
 
 /**
  * 새로운 여행 계획을 생성하는 서비스 함수.
@@ -30,4 +35,17 @@ export const getTripDetail = async (tripId: number): Promise<TripDetailResponseD
  */
 export const deleteTrip = async (tripId: number): Promise<void> => {
   await apiDeleteTrip(tripId)
+}
+
+/**
+ * 특정 여행 계획에 새로운 장소(아이템)를 추가하는 서비스 함수.
+ * @param tripId 여행 계획 ID
+ * @param itemData 추가할 아이템 정보
+ * @returns 생성된 여행 아이템 정보
+ */
+export const addTripItem = async (
+  tripId: number,
+  itemData: TripItemAddRequestDto,
+): Promise<TripItemResponseDto> => {
+  return await apiAddTripItem(tripId, itemData)
 }

--- a/src/services/trip.ts
+++ b/src/services/trip.ts
@@ -1,4 +1,8 @@
-import { createTrip as apiCreateTrip, getTripDetail as apiGetTripDetail } from '@/apis/trip'
+import {
+  createTrip as apiCreateTrip,
+  getTripDetail as apiGetTripDetail,
+  deleteTrip as apiDeleteTrip,
+} from '@/apis/trip'
 import type { TripDetailResponseDto } from '@/types/trip'
 
 /**
@@ -18,4 +22,12 @@ export const createTrip = async (): Promise<TripDetailResponseDto> => {
  */
 export const getTripDetail = async (tripId: number): Promise<TripDetailResponseDto> => {
   return await apiGetTripDetail(tripId)
+}
+
+/**
+ * 특정 여행 계획을 삭제하는 서비스 함수.
+ * @param tripId 삭제할 여행 계획의 ID
+ */
+export const deleteTrip = async (tripId: number): Promise<void> => {
+  await apiDeleteTrip(tripId)
 }

--- a/src/services/trip.ts
+++ b/src/services/trip.ts
@@ -3,11 +3,13 @@ import {
   getTripDetail as apiGetTripDetail,
   deleteTrip as apiDeleteTrip,
   syncTripItems as apiSyncTripItems,
+  updateTrip as apiUpdateTrip,
 } from '@/apis/trip'
 import type {
   TripDetailResponseDto,
   TripItemResponseDto,
   TripItemSyncRequestDto,
+  TripUpdateRequestDto,
 } from '@/types/trip'
 
 /**
@@ -48,4 +50,17 @@ export const syncTripItems = async (
   syncData: TripItemSyncRequestDto,
 ): Promise<TripItemResponseDto[]> => {
   return await apiSyncTripItems(tripId, syncData)
+}
+
+/**
+ * 여행의 기본 정보(제목, 날짜, 상태, 공개 여부)를 수정하는 서비스 함수.
+ * @param tripId 수정할 여행의 ID
+ * @param updateData 수정할 여행 정보
+ * @returns 수정된 여행의 상세 정보 (TripDetailResponseDto)
+ */
+export const updateTrip = async (
+  tripId: number,
+  updateData: TripUpdateRequestDto,
+): Promise<TripDetailResponseDto> => {
+  return await apiUpdateTrip(tripId, updateData)
 }

--- a/src/services/trip.ts
+++ b/src/services/trip.ts
@@ -1,0 +1,21 @@
+import { createTrip as apiCreateTrip, getTripDetail as apiGetTripDetail } from '@/apis/trip'
+import type { TripDetailResponseDto } from '@/types/trip'
+
+/**
+ * 새로운 여행 계획을 생성하는 서비스 함수.
+ * API 계층의 createTrip 함수를 호출하고 결과를 반환합니다.
+ * @returns 생성된 여행의 상세 정보 (TripDetailResponseDto)
+ */
+export const createTrip = async (): Promise<TripDetailResponseDto> => {
+  return await apiCreateTrip()
+}
+
+/**
+ * 특정 여행 계획의 상세 정보를 조회하는 서비스 함수.
+ * API 계층의 getTripDetail 함수를 호출하고 결과를 반환합니다.
+ * @param tripId 조회할 여행 계획의 ID
+ * @returns 여행 계획의 상세 정보 (TripDetailResponseDto)
+ */
+export const getTripDetail = async (tripId: number): Promise<TripDetailResponseDto> => {
+  return await apiGetTripDetail(tripId)
+}

--- a/src/services/trip.ts
+++ b/src/services/trip.ts
@@ -2,12 +2,12 @@ import {
   createTrip as apiCreateTrip,
   getTripDetail as apiGetTripDetail,
   deleteTrip as apiDeleteTrip,
-  addTripItem as apiAddTripItem,
+  syncTripItems as apiSyncTripItems,
 } from '@/apis/trip'
 import type {
   TripDetailResponseDto,
-  TripItemAddRequestDto,
   TripItemResponseDto,
+  TripItemSyncRequestDto,
 } from '@/types/trip'
 
 /**
@@ -38,14 +38,14 @@ export const deleteTrip = async (tripId: number): Promise<void> => {
 }
 
 /**
- * 특정 여행 계획에 새로운 장소(아이템)를 추가하는 서비스 함수.
- * @param tripId 여행 계획 ID
- * @param itemData 추가할 아이템 정보
- * @returns 생성된 여행 아이템 정보
+ * 여행 아이템 목록 전체를 동기화하는 서비스 함수.
+ * @param tripId 동기화할 여행의 ID
+ * @param syncData 날짜별 아이템 목록
+ * @returns 변경이 완료된 전체 아이템 목록
  */
-export const addTripItem = async (
+export const syncTripItems = async (
   tripId: number,
-  itemData: TripItemAddRequestDto,
-): Promise<TripItemResponseDto> => {
-  return await apiAddTripItem(tripId, itemData)
+  syncData: TripItemSyncRequestDto,
+): Promise<TripItemResponseDto[]> => {
+  return await apiSyncTripItems(tripId, syncData)
 }

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -28,8 +28,12 @@ export interface Trip {
   completedDate?: string
 }
 
+export type TripStatus = 'DRAFT' | 'PLANNED' | 'COMPLETED'
+export type TripVisibility = 'PUBLIC' | 'PRIVATE'
+
 // 장소 정보를 나타내는 인터페이스 (API 응답용)
 export interface Spot {
+  id: number
   kakaoPlaceId: string
   name: string
   address: string
@@ -37,7 +41,7 @@ export interface Spot {
   lat: number
   lng: number
   placeUrl: string
-  thumbnailUrl?: string // 썸네일 URL은 선택 사항
+  thumbnailUrl?: string
 }
 
 // 여행 아이템 응답 DTO 인터페이스
@@ -55,7 +59,8 @@ export interface TripDetailResponseDto {
   title: string
   startDate?: string // 시작일은 선택 사항
   endDate?: string // 종료일은 선택 사항
-  status: 'DRAFT' | 'PUBLIC' // 여행 상태 (임시 또는 공개)
+  status: TripStatus
+  visibility: TripVisibility
   isOwner: boolean // 현재 사용자가 여행의 소유자인지 여부
   tripItems: TripItemResponseDto[] // 여행에 포함된 아이템 목록
 }
@@ -66,8 +71,18 @@ export interface TripResponseDto {
   title: string
   startDate?: string
   endDate?: string
-  status: 'DRAFT' | 'PUBLIC'
+  status: TripStatus
+  visibility: TripVisibility
   isOwner: boolean
+}
+
+// 여행 정보 수정 요청 DTO
+export interface TripUpdateRequestDto {
+  title: string
+  startDate?: string
+  endDate?: string
+  status: TripStatus
+  visibility: TripVisibility
 }
 
 // 동기화 요청 시 신규 아이템을 위한 spot 정보

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -1,7 +1,8 @@
 // src/types/trip.ts
 
 export interface Place {
-  id: number
+  id: number // tripItemId 또는 초기 kakaoPlaceId
+  kakaoPlaceId: string // 장소의 고유 카카오 ID
   name: string
   address: string
   category: string
@@ -28,42 +29,62 @@ export interface Trip {
 
 // 장소 정보를 나타내는 인터페이스 (API 응답용)
 export interface Spot {
-  kakaoPlaceId: string;
-  name: string;
-  address: string;
-  category: string;
-  lat: number;
-  lng: number;
-  placeUrl: string;
-  thumbnailUrl?: string; // 썸네일 URL은 선택 사항
+  kakaoPlaceId: string
+  name: string
+  address: string
+  category: string
+  lat: number
+  lng: number
+  placeUrl: string
+  thumbnailUrl?: string // 썸네일 URL은 선택 사항
 }
 
 // 여행 아이템 응답 DTO 인터페이스
 export interface TripItemResponseDto {
-  id: number; // tripItemId를 id로 변경
-  dayNumber: number;
-  orderIndex: number;
-  memo?: string; // 메모는 선택 사항
-  spot: Spot;
+  id: number // tripItemId를 id로 변경
+  dayNumber: number
+  orderIndex: number
+  memo?: string // 메모는 선택 사항
+  spot: Spot
 }
 
 // 여행 상세 응답 DTO 인터페이스
 export interface TripDetailResponseDto {
-  id: number; // tripId를 id로 변경
-  title: string;
-  startDate?: string; // 시작일은 선택 사항
-  endDate?: string; // 종료일은 선택 사항
-  status: 'DRAFT' | 'PUBLIC'; // 여행 상태 (임시 또는 공개)
-  isOwner: boolean; // 현재 사용자가 여행의 소유자인지 여부
-  tripItems: TripItemResponseDto[]; // 여행에 포함된 아이템 목록
+  id: number // tripId를 id로 변경
+  title: string
+  startDate?: string // 시작일은 선택 사항
+  endDate?: string // 종료일은 선택 사항
+  status: 'DRAFT' | 'PUBLIC' // 여행 상태 (임시 또는 공개)
+  isOwner: boolean // 현재 사용자가 여행의 소유자인지 여부
+  tripItems: TripItemResponseDto[] // 여행에 포함된 아이템 목록
 }
 
 // 여행 목록 응답 DTO 인터페이스 (상세 정보 제외)
 export interface TripResponseDto {
-  id: number; // tripId를 id로 변경
-  title: string;
-  startDate?: string;
-  endDate?: string;
-  status: 'DRAFT' | 'PUBLIC';
-  isOwner: boolean;
+  id: number // tripId를 id로 변경
+  title: string
+  startDate?: string
+  endDate?: string
+  status: 'DRAFT' | 'PUBLIC'
+  isOwner: boolean
+}
+
+// 여행 아이템 추가 요청 시 spot 정보 DTO
+export interface SpotAddDto {
+  kakaoPlaceId: string
+  name: string
+  address: string
+  category: string
+  lat: number
+  lng: number
+  placeUrl: string
+  thumbnailUrl?: string
+}
+
+// 여행 아이템 추가 요청 DTO
+export interface TripItemAddRequestDto {
+  dayNumber: number
+  orderIndex: number
+  memo?: string
+  spot: SpotAddDto
 }

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -25,3 +25,45 @@ export interface Trip {
   spotPreviews: { name: string }[]
   completedDate?: string
 }
+
+// 장소 정보를 나타내는 인터페이스 (API 응답용)
+export interface Spot {
+  kakaoPlaceId: string;
+  name: string;
+  address: string;
+  category: string;
+  lat: number;
+  lng: number;
+  placeUrl: string;
+  thumbnailUrl?: string; // 썸네일 URL은 선택 사항
+}
+
+// 여행 아이템 응답 DTO 인터페이스
+export interface TripItemResponseDto {
+  id: number; // tripItemId를 id로 변경
+  dayNumber: number;
+  orderIndex: number;
+  memo?: string; // 메모는 선택 사항
+  spot: Spot;
+}
+
+// 여행 상세 응답 DTO 인터페이스
+export interface TripDetailResponseDto {
+  id: number; // tripId를 id로 변경
+  title: string;
+  startDate?: string; // 시작일은 선택 사항
+  endDate?: string; // 종료일은 선택 사항
+  status: 'DRAFT' | 'PUBLIC'; // 여행 상태 (임시 또는 공개)
+  isOwner: boolean; // 현재 사용자가 여행의 소유자인지 여부
+  tripItems: TripItemResponseDto[]; // 여행에 포함된 아이템 목록
+}
+
+// 여행 목록 응답 DTO 인터페이스 (상세 정보 제외)
+export interface TripResponseDto {
+  id: number; // tripId를 id로 변경
+  title: string;
+  startDate?: string;
+  endDate?: string;
+  status: 'DRAFT' | 'PUBLIC';
+  isOwner: boolean;
+}

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -1,15 +1,16 @@
 // src/types/trip.ts
 
 export interface Place {
-  id: number // tripItemId 또는 초기 kakaoPlaceId
+  id?: number // 동기화 전에는 id가 없을 수 있음 (tripItemId)
   kakaoPlaceId: string // 장소의 고유 카카오 ID
   name: string
   address: string
   category: string
   lat: number
   lng: number
-  phone?: string // 선택적 속성 (?)
-  url?: string // 선택적 속성 (?)
+  phone?: string
+  url?: string
+  memo?: string // 아이템 메모
 }
 
 export interface DayPlan {
@@ -69,7 +70,7 @@ export interface TripResponseDto {
   isOwner: boolean
 }
 
-// 여행 아이템 추가 요청 시 spot 정보 DTO
+// 동기화 요청 시 신규 아이템을 위한 spot 정보
 export interface SpotAddDto {
   kakaoPlaceId: string
   name: string
@@ -81,10 +82,17 @@ export interface SpotAddDto {
   thumbnailUrl?: string
 }
 
-// 여행 아이템 추가 요청 DTO
-export interface TripItemAddRequestDto {
-  dayNumber: number
-  orderIndex: number
+// 동기화 요청 시 개별 아이템 DTO
+export interface ItemSyncDto {
+  tripItemId?: number
+  spot?: SpotAddDto
   memo?: string
-  spot: SpotAddDto
+}
+
+// 여행 아이템 목록 전체 동기화 요청 DTO
+export interface TripItemSyncRequestDto {
+  days: {
+    dayNumber: number
+    items: ItemSyncDto[]
+  }[]
 }

--- a/src/views/TripPlanView.vue
+++ b/src/views/TripPlanView.vue
@@ -128,7 +128,10 @@ const mapInteraction = useMapInteraction({
 const { kakaoMapRef } = mapInteraction
 
 // 저장/뒤로가기 연결
-const tripSave = () => trip.saveTrip(closeSearchPanel)
+const tripSave = () => {
+  console.log('tripSave called');
+  trip.saveTrip(closeSearchPanel);
+}
 const tripBack = () => trip.goBack(closeSearchPanel)
 </script>
 

--- a/src/views/TripPlanView.vue
+++ b/src/views/TripPlanView.vue
@@ -24,9 +24,9 @@
         @update:search-query="searchQuery = $event"
         @update:active-day="trip.activeDay.value = $event"
         @search="mapInteraction.triggerSearch"
-        @remove-place="trip.removePlace"
         @add-day="trip.addDay"
         @remove-day="trip.removeDay"
+        @remove-place="trip.removePlace"
         @update-places="trip.updatePlaces"
         @click-place="mapInteraction.handlePlaceClick"
       />

--- a/src/views/TripView.vue
+++ b/src/views/TripView.vue
@@ -12,7 +12,7 @@
         </div>
 
         <button
-          @click="handleNavigate('create-trip')"
+          @click="handleCreateNewTrip"
           class="flex items-center justify-center gap-3 px-6 py-4 bg-[#F9CA6B] border-[3px] border-black rounded-2xl font-black text-sm tracking-tight shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:translate-x-[-2px] hover:translate-y-[-2px] transition-all uppercase w-full md:w-auto focus:outline-none"
         >
           <Plus class="w-5 h-5" stroke-width="3" />
@@ -90,12 +90,28 @@ import TripDetailModal from '@/components/modal/TripDetailModal.vue'
 import ScrollToTop from '@/components/common/ScrollToTop.vue'
 import { initialTrips } from '@/data/trips'
 import type { Trip } from '@/types/trip'
+import { useRouter } from 'vue-router' // useRouter import
+import { createTrip } from '@/services/trip' // createTrip import
 
 const { handleNavigate } = useNavigate()
+const router = useRouter() // useRouter 인스턴스 생성
 
 const activeTab = ref<'all' | 'planning' | 'completed' | 'saved'>('all')
 const tripsList = ref<Trip[]>(initialTrips)
 const selectedTrip = ref<any>(null)
+
+// 새로운 여행 계획 생성 핸들러
+const handleCreateNewTrip = async () => {
+  try {
+    const newTrip = await createTrip(); // API 호출
+    console.log('newTrip:', newTrip); // newTrip 값 확인
+    alert('새로운 여행 계획이 생성되었습니다!');
+    router.push(`/trips/${newTrip.id}`); // 생성된 여행의 상세 페이지로 이동 (newTrip.id 사용)
+  } catch (error) {
+    console.error('여행 계획 생성 실패:', error);
+    alert('여행 계획 생성에 실패했습니다.');
+  }
+}
 
 // 탭 필터링 로직
 const planningTrips = computed(() => tripsList.value.filter((t) => t.status === '계획중'))

--- a/src/views/TripView.vue
+++ b/src/views/TripView.vue
@@ -103,13 +103,12 @@ const selectedTrip = ref<any>(null)
 // 새로운 여행 계획 생성 핸들러
 const handleCreateNewTrip = async () => {
   try {
-    const newTrip = await createTrip(); // API 호출
-    console.log('newTrip:', newTrip); // newTrip 값 확인
-    alert('새로운 여행 계획이 생성되었습니다!');
-    router.push(`/trips/${newTrip.id}`); // 생성된 여행의 상세 페이지로 이동 (newTrip.id 사용)
+    const newTrip = await createTrip() // API 호출
+    console.log('newTrip:', newTrip) // newTrip 값 확인
+    router.push(`/trips/${newTrip.id}`) // 생성된 여행의 상세 페이지로 이동 (newTrip.id 사용)
   } catch (error) {
-    console.error('여행 계획 생성 실패:', error);
-    alert('여행 계획 생성에 실패했습니다.');
+    console.error('여행 계획 생성 실패:', error)
+    alert('여행 계획 생성에 실패했습니다.')
   }
 }
 


### PR DESCRIPTION
## 요약
<img width="800" height="" alt="image" src="https://github.com/user-attachments/assets/9d4aeca3-61c2-49e8-bff7-1fe834df76f0" />


  TripPlanView의 모든 핵심 기능들을 백엔드 API와 완전히 연동했습니다. 장소 추가/삭제, 여행
  제목/날짜/상태 변경 등 여행 계획과 관련된 모든 사용자 액션이 이제 서버에 반영되고 관리됩니다.
  이를 통해 여행 계획 페이지의 기능적 완성도를 높이고 데이터 일관성을 확보했습니다.

## 여행 계획 페이지 API 흐름 요약:
  TripPlanView는 여행 계획의 생성, 조회, 수정, 삭제와 관련된 모든 백엔드 API와 연동되어
  있습니다. 주요 API 호출 흐름은 다음과 같습니다.


   1. 여행 계획 초기 생성 (POST /trips)
       * 트리거: "새로 생성하기" 또는 유사한 버튼 클릭 시.
       * 동작: 빈 여행 계획을 생성하기 위해 `POST /trips API`를 호출합니다.
       * 결과: 백엔드는 `DRAFT` 상태의 새로운 여행 ID와 기본 정보를 반환하며, 프론트엔드는 이
         ID를 기반으로 TripPlanView로 이동합니다.


   2. 여행 계획 상세 정보 조회 (GET /trips/{tripId})
       * 트리거: TripPlanView 진입 시 (새로 생성된 여행이든 기존 여행이든).
       * 동작: `GET /trips/{tripId}` API를 호출하여 해당 tripId에 대한 여행의 모든 상세
         정보(제목, 날짜, 상태, 공개 여부, 그리고 각 날짜별 장소(spot 객체 포함) 목록)를
         불러옵니다.
       * 결과: 프론트엔드는 이 정보를 기반으로 UI를 렌더링하고, useTripPlan 컴포저블의 상태를
         초기화합니다.


   3. 여행 계획 저장 (SAVE 버튼 클릭 시)
       * 트리거: TripPlanView 내 "저장(SAVE)"버튼 클릭 시.
       * 동작: 두 가지 API 호출이 순차적으로 발생합니다.
           * 장소 목록 동기화 (`PUT /trips/{tripId}/items`): 현재 프론트엔드에 있는 날짜별 장소
             목록을 백엔드와 동기화하기 위해 `PUT /trips/{tripId}/items` API를 호출합니다. 이
             API는 장소의 추가, 수정, 삭제를 처리합니다.
           * 여행 메타데이터 업데이트 (`PUT /trips/{tripId}`): 여행의 제목, 시작일, 종료일,
             상태(PLANNED), 공개 여부(PUBLIC) 등 기본 정보를 업데이트하기 위해 `PUT 
             /trips/{tripId}` API를 호출합니다.
       * 결과: 두 API 호출이 성공하면, 프론트엔드는 `GET /trips/{tripId}`를 다시 호출하여 최신
         상태의 여행 정보를 불러와 UI를 업데이트하고, 편집 모드를 종료합니다.


   4. 여행 계획 삭제 (DELETE 버튼 클릭 시)
       * 트리거: TripPlanView 내 "삭제(휴지통)" 버튼 클릭 시.
       * 동작: `DELETE /trips/{tripId}` API를 호출하여 해당 여행 계획을 백엔드에서 완전히
         삭제합니다.
       * 결과: 여행이 성공적으로 삭제되면, 프론트엔드는 사용자에게 알림 후 여행 목록 페이지로
         이동합니다.


   5. 여행 계획 작성 취소 (뒤로가기 버튼 클릭 시, 편집 모드일 때)
       * 트리거: TripPlanView 내 "뒤로가기" 버튼 클릭 시, 편집 모드인 경우.
       * 동작: 사용자에게 변경 사항 취소 여부를 확인합니다.
           * 만약 현재 여행이 `DRAFT` 상태였다면, `DELETE /trips/{tripId}` API를 호출하여 임시
             여행 계획을 삭제합니다.
           * 그렇지 않다면, 편집 모드 진입 시 백업해둔 데이터로 로컬 상태를 복원합니다.
       * 결과: 변경 사항이 취소되거나 임시 여행이 삭제되며, 프론트엔드는 이전 페이지 또는 여행
         목록 페이지로 이동합니다.