### PR TITLE
feat: 여행 계획 페이지 및 모달 백엔드 api 연동

### DIFF
--- a/src/apis/trip.ts
+++ b/src/apis/trip.ts
@@ -2,8 +2,11 @@ import apiClient from '@/services/api'
 import type {
   TripDetailResponseDto,
   TripItemResponseDto,
-  TripItemSyncRequestDto,
+  TripItemsUpdateRequestDto, // Changed from TripItemSyncRequestDto
   TripUpdateRequestDto,
+  TripResponseDto,
+  TripSummaryResponseDto, // Added
+  TripStatus, // Added
 } from '@/types/trip'
 
 // API 호출 함수
@@ -43,7 +46,7 @@ export const deleteTrip = async (tripId: number): Promise<void> => {
  */
 export const syncTripItems = async (
   tripId: number,
-  syncData: TripItemSyncRequestDto,
+  syncData: TripItemsUpdateRequestDto, // Changed type
 ): Promise<TripItemResponseDto[]> => {
   const response = await apiClient.put<TripItemResponseDto[]>(`/trips/${tripId}/items`, syncData)
   return response.data
@@ -62,3 +65,25 @@ export const updateTrip = async (
   const response = await apiClient.put<TripDetailResponseDto>(`/trips/${tripId}`, updateData)
   return response.data
 }
+
+/**
+ * 내 여행 목록을 조회합니다.
+ * @param status 여행 상태별 필터링 (DRAFT, PLANNED, COMPLETED)
+ * @returns 내 여행 목록 (TripResponseDto 배열)
+ */
+export const getMyTrips = async (status?: TripStatus): Promise<TripResponseDto[]> => {
+  const response = await apiClient.get<TripResponseDto[]>('/trips', {
+    params: { status },
+  })
+  return response.data
+}
+
+/**
+ * 내 여행 요약 목록을 조회합니다 (카드용).
+ * @returns 내 여행 요약 목록 (TripSummaryResponseDto 배열)
+ */
+export const getMyTripSummaries = async (): Promise<TripSummaryResponseDto[]> => {
+  const response = await apiClient.get<TripSummaryResponseDto[]>('/trips/summary')
+  return response.data
+}
+

--- a/src/components/modal/TripDetailModal.vue
+++ b/src/components/modal/TripDetailModal.vue
@@ -25,7 +25,7 @@
               </div>
               <div class="flex items-center gap-2">
                 <MapPin :size="18" :stroke-width="2.5" />
-                <span>{{ trip.spots }}개 장소</span>
+                <span>{{ trip.tripItems.length }}개 장소</span>
               </div>
             </div>
           </div>
@@ -131,94 +131,34 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { Calendar, MapPin, Edit } from 'lucide-vue-next'
 import PlaceDetailModal from './PlaceDetailModal.vue'
 import KakaoMap from '@/components/common/KakaoMap.vue'
+import { TripDetailResponseDto, SpotResponseDto } from '@/types/trip' // Import types
 
-interface Place {
-  id: number
-  name: string
-  address: string
-  category: string
-  lat?: number
-  lng?: number
-}
-
-interface DayPlan {
+interface DayPlanDisplay {
   dayNumber: number
-  places: Place[]
-}
-
-interface Trip {
-  id: number
-  title: string
-  spots: number
-  duration: string
-  description: string
-  tags: string[]
-  views: number
-  imageUrl: string
+  places: SpotResponseDto[]
 }
 
 const props = defineProps<{
-  trip: Trip
+  trip: TripDetailResponseDto & { duration?: string; description?: string; views?: number; imageUrl?: string } // Extend with optional fields from TripView
 }>()
 
 const emit = defineEmits(['close', 'edit'])
 
 const activeDay = ref(1)
-const selectedPlace = ref<Place | null>(null)
+const selectedPlace = ref<SpotResponseDto | null>(null) // Changed type
 
-// Mock data - 실제로는 API에서 가져와야 함
-const days = ref<DayPlan[]>([
-  {
-    dayNumber: 1,
-    places: [
-      {
-        id: 1,
-        name: '대림창고',
-        address: '서울시 성동구 성수동1가 656-1',
-        category: '카페',
-        lat: 37.5443,
-        lng: 127.0557,
-      },
-      {
-        id: 2,
-        name: '그리노 성수',
-        address: '서울시 성동구 왕십리로 83-21',
-        category: '카페',
-        lat: 37.5445,
-        lng: 127.0559,
-      },
-      {
-        id: 3,
-        name: '테라로사 성수',
-        address: '서울시 성동구 아차산로7길 12',
-        category: '카페',
-        lat: 37.5448,
-        lng: 127.0562,
-      },
-    ],
-  },
-  {
-    dayNumber: 2,
-    places: [
-      {
-        id: 4,
-        name: '성수연방',
-        address: '서울시 성동구 연무장5길 7',
-        category: '카페',
-        lat: 37.544,
-        lng: 127.0555,
-      },
-      {
-        id: 5,
-        name: '서울숲',
-        address: '서울시 성동구 뚝섬로 273',
-        category: '공원',
-        lat: 37.5447,
-        lng: 127.0374,
-      },
-    ],
-  },
-])
+// trip.tripItems를 DayPlanDisplay[] 형태로 변환
+const days = computed<DayPlanDisplay[]>(() => {
+  const grouped = props.trip.tripItems.reduce((acc, item) => {
+    if (!acc[item.dayNumber]) {
+      acc[item.dayNumber] = { dayNumber: item.dayNumber, places: [] }
+    }
+    acc[item.dayNumber].places.push(item.spot)
+    return acc
+  }, {} as Record<number, DayPlanDisplay>)
+
+  return Object.values(grouped).sort((a, b) => a.dayNumber - b.dayNumber)
+})
 
 const currentDayPlaces = computed(() => {
   const day = days.value.find((d) => d.dayNumber === activeDay.value)

--- a/src/components/modal/TripDetailModal.vue
+++ b/src/components/modal/TripDetailModal.vue
@@ -21,7 +21,7 @@
             <div class="flex items-center gap-4 text-sm font-bold text-gray-600">
               <div class="flex items-center gap-2">
                 <Calendar :size="18" :stroke-width="2.5" />
-                <span>{{ trip.duration }}</span>
+                <span>{{ displayDuration }}</span>
               </div>
               <div class="flex items-center gap-2">
                 <MapPin :size="18" :stroke-width="2.5" />
@@ -190,6 +190,19 @@ const mapCenter = computed(() => {
 const handleEditClick = () => {
   emit('edit', props.trip)
 }
+
+const displayDuration = computed(() => {
+  const start = props.trip.startDate
+  const end = props.trip.endDate
+
+  if (start && end) {
+    return `${start} - ${end}`
+  } else if (start) {
+    return start
+  } else {
+    return '날짜 미정'
+  }
+})
 
 // ESC 키로 닫기
 const handleKeydown = (e: KeyboardEvent) => {

--- a/src/components/trip/TripCard.vue
+++ b/src/components/trip/TripCard.vue
@@ -101,23 +101,10 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { Calendar, Share2, Bookmark, MapPin } from 'lucide-vue-next'
-
-interface SpotPreview {
-  name: string
-}
-
-interface Trip {
-  id: number
-  title: string
-  spots: number
-  status: string
-  tags?: string[]
-  spotPreviews: SpotPreview[]
-  completedDate?: string
-}
+import { TripResponseDto, TripStatus } from '@/types/trip' // Import TripResponseDto and TripStatus
 
 const props = defineProps<{
-  trip: Trip
+  trip: TripResponseDto // Use TripResponseDto type
 }>()
 
 const emit = defineEmits<{
@@ -125,12 +112,12 @@ const emit = defineEmits<{
   (e: 'navigate', page: string, id?: number): void
 }>()
 
-const isBookmarked = ref(props.trip.status === '스크랩')
+const isBookmarked = ref(false) // Assuming bookmarking is not directly tied to API status anymore
 
-const statusColors: Record<string, string> = {
-  완료: '#F9CA6B',
-  계획중: '#9BCCC4',
-  스크랩: '#E88555',
+const statusColors: Record<TripStatus, string> = { // Use TripStatus enum
+  COMPLETED: '#F9CA6B',
+  PLANNED: '#9BCCC4',
+  DRAFT: '#E88555', // Assuming DRAFT maps to '스크랩' color for now
 }
 
 const headerColor = computed(() => statusColors[props.trip.status] || '#9BCCC4')

--- a/src/components/trip/TripCard.vue
+++ b/src/components/trip/TripCard.vue
@@ -7,7 +7,7 @@
       <div class="flex items-center justify-between mb-3 h-6">
         <div class="flex items-center gap-1.5 text-xs text-[#2C2C2C] font-bold">
           <Calendar class="w-3.5 h-3.5" stroke-width="2.5" />
-          <span>{{ trip.completedDate || '날짜 미정' }}</span>
+          <span>{{ displayDateRange }}</span>
         </div>
 
         <div class="flex items-center gap-1.5">
@@ -128,6 +128,22 @@ const getNumberColor = (idx: number) => numberColors[idx % numberColors.length]
 const handleShare = () => {
   alert('공유 기능 준비 중입니다!')
 }
+
+const displayDateRange = computed(() => {
+  const start = props.trip.startDate
+  const end = props.trip.endDate
+  const completed = props.trip.completedDate
+
+  if (start && end) {
+    return `${start} - ${end}`
+  } else if (start) {
+    return start
+  } else if (completed) {
+    return completed
+  } else {
+    return '날짜 미정'
+  }
+})
 </script>
 
 <style scoped>

--- a/src/services/trip.ts
+++ b/src/services/trip.ts
@@ -3,13 +3,16 @@ import {
   getTripDetail as apiGetTripDetail,
   deleteTrip as apiDeleteTrip,
   syncTripItems as apiSyncTripItems,
-  updateTrip as apiUpdateTrip,
+  getMyTrips as apiGetMyTrips,
+  getMyTripSummaries as apiGetMyTripSummaries,
 } from '@/apis/trip'
 import type {
   TripDetailResponseDto,
   TripItemResponseDto,
-  TripItemSyncRequestDto,
-  TripUpdateRequestDto,
+  TripItemsUpdateRequestDto, // Changed from TripItemSyncRequestDto
+  TripResponseDto,
+  TripSummaryResponseDto, // Added
+  TripStatus,
 } from '@/types/trip'
 
 /**
@@ -19,6 +22,25 @@ import type {
  */
 export const createTrip = async (): Promise<TripDetailResponseDto> => {
   return await apiCreateTrip()
+}
+
+/**
+ * 내 여행 목록을 조회하는 서비스 함수.
+ * API 계층의 getMyTrips 함수를 호출하고 결과를 반환합니다.
+ * @param status 여행 상태별 필터링 (DRAFT, PLANNED, COMPLETED)
+ * @returns 내 여행 목록 (TripResponseDto 배열)
+ */
+export const getMyTrips = async (status?: TripStatus): Promise<TripResponseDto[]> => {
+  return await apiGetMyTrips(status)
+}
+
+/**
+ * 내 여행 요약 목록을 조회하는 서비스 함수 (카드용).
+ * API 계층의 getMyTripSummaries 함수를 호출하고 결과를 반환합니다.
+ * @returns 내 여행 요약 목록 (TripSummaryResponseDto 배열)
+ */
+export const getMyTripSummaries = async (): Promise<TripSummaryResponseDto[]> => {
+  return await apiGetMyTripSummaries()
 }
 
 /**
@@ -47,20 +69,7 @@ export const deleteTrip = async (tripId: number): Promise<void> => {
  */
 export const syncTripItems = async (
   tripId: number,
-  syncData: TripItemSyncRequestDto,
+  syncData: TripItemsUpdateRequestDto, // Changed type
 ): Promise<TripItemResponseDto[]> => {
   return await apiSyncTripItems(tripId, syncData)
-}
-
-/**
- * 여행의 기본 정보(제목, 날짜, 상태, 공개 여부)를 수정하는 서비스 함수.
- * @param tripId 수정할 여행의 ID
- * @param updateData 수정할 여행 정보
- * @returns 수정된 여행의 상세 정보 (TripDetailResponseDto)
- */
-export const updateTrip = async (
-  tripId: number,
-  updateData: TripUpdateRequestDto,
-): Promise<TripDetailResponseDto> => {
-  return await apiUpdateTrip(tripId, updateData)
 }

--- a/src/services/trip.ts
+++ b/src/services/trip.ts
@@ -3,15 +3,17 @@ import {
   getTripDetail as apiGetTripDetail,
   deleteTrip as apiDeleteTrip,
   syncTripItems as apiSyncTripItems,
+  updateTrip as apiUpdateTrip, // Added
   getMyTrips as apiGetMyTrips,
   getMyTripSummaries as apiGetMyTripSummaries,
 } from '@/apis/trip'
 import type {
   TripDetailResponseDto,
   TripItemResponseDto,
-  TripItemsUpdateRequestDto, // Changed from TripItemSyncRequestDto
+  TripItemsUpdateRequestDto,
+  TripUpdateRequestDto, // Added
   TripResponseDto,
-  TripSummaryResponseDto, // Added
+  TripSummaryResponseDto,
   TripStatus,
 } from '@/types/trip'
 
@@ -69,7 +71,20 @@ export const deleteTrip = async (tripId: number): Promise<void> => {
  */
 export const syncTripItems = async (
   tripId: number,
-  syncData: TripItemsUpdateRequestDto, // Changed type
+  syncData: TripItemsUpdateRequestDto,
 ): Promise<TripItemResponseDto[]> => {
   return await apiSyncTripItems(tripId, syncData)
+}
+
+/**
+ * 여행의 기본 정보(제목, 날짜, 상태, 공개 여부)를 수정하는 서비스 함수.
+ * @param tripId 수정할 여행의 ID
+ * @param updateData 수정할 여행 정보
+ * @returns 수정된 여행의 상세 정보 (TripDetailResponseDto)
+ */
+export const updateTrip = async (
+  tripId: number,
+  updateData: TripUpdateRequestDto,
+): Promise<TripDetailResponseDto> => {
+  return await apiUpdateTrip(tripId, updateData)
 }

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -18,96 +18,127 @@ export interface DayPlan {
   places: Place[]
 }
 
-export interface Trip {
-  id: number
-  title: string
-  spots: number
-  status: string
-  tags?: string[]
-  spotPreviews: { name: string }[]
-  completedDate?: string
-}
+// src/types/trip.ts
 
-export type TripStatus = 'DRAFT' | 'PLANNED' | 'COMPLETED'
-export type TripVisibility = 'PUBLIC' | 'PRIVATE'
-
-// 장소 정보를 나타내는 인터페이스 (API 응답용)
-export interface Spot {
-  id: number
-  kakaoPlaceId: string
+export interface Place {
+  id?: number // 동기화 전에는 id가 없을 수 있음 (tripItemId)
+  kakaoPlaceId: string // 장소의 고유 카카오 ID
   name: string
   address: string
   category: string
   lat: number
   lng: number
-  placeUrl: string
-  thumbnailUrl?: string
+  phone?: string
+  url?: string
+  memo?: string // 아이템 메모
+}
+
+export interface DayPlan {
+  dayNumber: number
+  places: Place[]
+}
+
+export enum TripStatus {
+  DRAFT = 'DRAFT',
+  PLANNED = 'PLANNED',
+  COMPLETED = 'COMPLETED',
+}
+export type TripVisibility = 'PUBLIC' | 'PRIVATE'
+
+// 장소 정보를 나타내는 인터페이스 (API 응답용) - SpotResponseDto에 해당
+export interface SpotResponseDto {
+  id: number
+  kakaoPlaceId: string
+  name: string
+  address?: string // nullable
+  category?: string // nullable
+  lat: number
+  lng: number
+  placeUrl?: string // nullable
+  thumbnailUrl?: string // nullable
+}
+
+// 장소 정보를 나타내는 인터페이스 (API 요청용) - SpotRequestDto에 해당
+export interface SpotRequestDto {
+  kakaoPlaceId: string
+  name: string
+  address?: string // nullable
+  category?: string // nullable
+  lat: number
+  lng: number
+  placeUrl?: string // nullable
+  thumbnailUrl?: string // nullable
 }
 
 // 여행 아이템 응답 DTO 인터페이스
 export interface TripItemResponseDto {
-  id: number // tripItemId를 id로 변경
+  id: number
   dayNumber: number
   orderIndex: number
-  memo?: string // 메모는 선택 사항
-  spot: Spot
+  memo?: string // nullable
+  spot: SpotResponseDto
 }
 
 // 여행 상세 응답 DTO 인터페이스
 export interface TripDetailResponseDto {
-  id: number // tripId를 id로 변경
+  id: number
   title: string
-  startDate?: string // 시작일은 선택 사항
-  endDate?: string // 종료일은 선택 사항
-  status: TripStatus
-  visibility: TripVisibility
-  isOwner: boolean // 현재 사용자가 여행의 소유자인지 여부
-  tripItems: TripItemResponseDto[] // 여행에 포함된 아이템 목록
-}
-
-// 여행 목록 응답 DTO 인터페이스 (상세 정보 제외)
-export interface TripResponseDto {
-  id: number // tripId를 id로 변경
-  title: string
-  startDate?: string
-  endDate?: string
+  startDate?: string // nullable
+  endDate?: string // nullable
   status: TripStatus
   visibility: TripVisibility
   isOwner: boolean
+  tripItems: TripItemResponseDto[]
+}
+
+// 여행 목록 응답 DTO 인터페이스 (TripCard에서 필요한 필드 포함)
+export interface TripResponseDto {
+  id: number
+  title: string
+  startDate?: string // nullable
+  endDate?: string // nullable
+  status: TripStatus
+  visibility: TripVisibility
+  isOwner: boolean
+  spots: number // 추가됨
+  tags?: string[] // 추가됨, nullable
+  spotPreviews: { name: string }[] // 추가됨
+  completedDate?: string // 추가됨, nullable
+}
+
+// 여행 요약 응답 DTO 인터페이스 (새로 추가됨)
+export interface TripSummaryResponseDto {
+  id: number
+  title: string
+  startDate: string
+  endDate: string
+  status: TripStatus
+  visibility: TripVisibility
+  day1Items: TripItemResponseDto[]
 }
 
 // 여행 정보 수정 요청 DTO
 export interface TripUpdateRequestDto {
   title: string
-  startDate?: string
-  endDate?: string
+  startDate?: string // nullable
+  endDate?: string // nullable
   status: TripStatus
   visibility: TripVisibility
 }
 
-// 동기화 요청 시 신규 아이템을 위한 spot 정보
-export interface SpotAddDto {
-  kakaoPlaceId: string
-  name: string
-  address: string
-  category: string
-  lat: number
-  lng: number
-  placeUrl: string
-  thumbnailUrl?: string
+// 여행 아이템 목록 전체 수정 요청 DTO (TripItemSyncRequestDto -> TripItemsUpdateRequestDto)
+export interface TripItemsUpdateRequestDto {
+  days: TripItemsUpdateRequestDto_Day[]
 }
 
-// 동기화 요청 시 개별 아이템 DTO
-export interface ItemSyncDto {
-  tripItemId?: number
-  spot?: SpotAddDto
-  memo?: string
+export interface TripItemsUpdateRequestDto_Day {
+  dayNumber: number
+  items: TripItemsUpdateRequestDto_ItemSync[]
 }
 
-// 여행 아이템 목록 전체 동기화 요청 DTO
-export interface TripItemSyncRequestDto {
-  days: {
-    dayNumber: number
-    items: ItemSyncDto[]
-  }[]
+export interface TripItemsUpdateRequestDto_ItemSync {
+  tripItemId?: number // nullable
+  spot?: SpotRequestDto // nullable, 새로운 아이템인 경우 필수
+  memo?: string // nullable
 }
+

--- a/src/views/TripView.vue
+++ b/src/views/TripView.vue
@@ -81,23 +81,39 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { Plus } from 'lucide-vue-next'
 import { useNavigate } from '@/composables/common/useNavagation'
 import TravelNavbar from '@/components/common/TravelNavbar.vue'
 import TripCard from '@/components/trip/TripCard.vue'
 import TripDetailModal from '@/components/modal/TripDetailModal.vue'
 import ScrollToTop from '@/components/common/ScrollToTop.vue'
-import { initialTrips } from '@/data/trips'
-import type { Trip } from '@/types/trip'
-import { useRouter } from 'vue-router' // useRouter import
-import { createTrip } from '@/services/trip' // createTrip import
+import { useRouter } from 'vue-router'
+import { createTrip, getMyTrips } from '@/services/trip'
+import { TripResponseDto, TripStatus } from '@/types/trip'
+
+// TODO: TripCard에서 필요한 spots, tags, spotPreviews, completedDate 필드가 TripResponseDto에 없음.
+// 현재는 TripResponseDto를 기반으로 하되, TripCard에 필요한 필드는 임시로 처리하거나,
+// TripCard의 props 타입을 TripResponseDto에 맞게 조정해야 합니다.
+// 장기적으로는 백엔드 API에서 해당 정보를 제공하거나, TripCard 컴포넌트의 요구사항을 조정해야 합니다.
 
 const { handleNavigate } = useNavigate()
-const router = useRouter() // useRouter 인스턴스 생성
+const router = useRouter()
 
-const activeTab = ref<'all' | 'planning' | 'completed' | 'saved'>('all')
-const tripsList = ref<Trip[]>(initialTrips)
+const activeTab = ref<'all' | 'PLANNED' | 'COMPLETED' | 'saved'>('all') // Changed to use TripStatus enum values
+const tripsList = ref<TripResponseDto[]>([]) // Changed to TripResponseDto[]
+
+onMounted(async () => {
+  try {
+    const response = await getMyTrips()
+    tripsList.value = response
+    console.log('Fetched tripsList:', tripsList.value) // Added log
+  } catch (error) {
+    console.error('내 여행 목록 조회 실패:', error)
+    // 에러 처리 로직 추가 (예: 사용자에게 알림)
+  }
+})
+
 const selectedTrip = ref<any>(null)
 
 // 새로운 여행 계획 생성 핸들러
@@ -113,34 +129,38 @@ const handleCreateNewTrip = async () => {
 }
 
 // 탭 필터링 로직
-const planningTrips = computed(() => tripsList.value.filter((t) => t.status === '계획중'))
-const completedTrips = computed(() => tripsList.value.filter((t) => t.status === '완료'))
-const savedTrips = computed(() => tripsList.value.filter((t) => t.status === '스크랩'))
+const planningTrips = computed(() => tripsList.value.filter((t) => t.status === TripStatus.PLANNED))
+const completedTrips = computed(() => tripsList.value.filter((t) => t.status === TripStatus.COMPLETED))
+const savedTrips = computed(() => tripsList.value.filter((t) => t.status === '스크랩')) // '스크랩'은 TripStatus에 없으므로 로컬 필터링 유지
 
 const displayTrips = computed(() => {
-  if (activeTab.value === 'planning') return planningTrips.value
-  if (activeTab.value === 'completed') return completedTrips.value
-  if (activeTab.value === 'saved') return savedTrips.value
-  return tripsList.value
+  const filteredTrips = (() => {
+    if (activeTab.value === 'PLANNED') return planningTrips.value
+    if (activeTab.value === 'COMPLETED') return completedTrips.value
+    if (activeTab.value === 'saved') return savedTrips.value
+    return tripsList.value
+  })();
+  console.log('displayTrips:', filteredTrips); // Added log
+  return filteredTrips;
 })
 
 const tabs = [
   { id: 'all', label: '전체' },
-  { id: 'planning', label: '계획중' },
-  { id: 'completed', label: '완료' },
+  { id: 'PLANNED', label: '계획중' }, // Changed to PLANNED
+  { id: 'COMPLETED', label: '완료' }, // Changed to COMPLETED
   { id: 'saved', label: '스크랩' },
 ]
 
 const getCount = (tabId: string) => {
   if (tabId === 'all') return tripsList.value.length
-  if (tabId === 'planning') return planningTrips.value.length
-  if (tabId === 'completed') return completedTrips.value.length
+  if (tabId === 'PLANNED') return planningTrips.value.length
+  if (tabId === 'COMPLETED') return completedTrips.value.length
   if (tabId === 'saved') return savedTrips.value.length
   return 0
 }
 
 const groupedCompletedTrips = computed(() => {
-  const groups: Record<string, Trip[]> = {}
+  const groups: Record<string, TripResponseDto[]> = {} // Changed to TripResponseDto[]
   completedTrips.value.forEach((trip) => {
     if (trip.completedDate) {
       const monthKey = trip.completedDate.substring(0, 7)
@@ -155,7 +175,7 @@ const groupedCompletedTrips = computed(() => {
         acc[key] = groups[key]
         return acc
       },
-      {} as Record<string, Trip[]>,
+      {} as Record<string, TripResponseDto[]>, // Changed to TripResponseDto[]
     )
 })
 
@@ -173,9 +193,9 @@ const handleOpenModal = (tripId: number) => {
     selectedTrip.value = {
       ...trip,
       duration: '반나절', // Mock Data
-      description: trip.spotPreviews.map((s) => s.name).join(' → '),
-      views: 1240,
-      imageUrl: '',
+      description: trip.spotPreviews && trip.spotPreviews.length > 0 ? trip.spotPreviews.map((s) => s.name).join(' → ') : '장소 없음',
+      views: 1240, // Mock Data
+      imageUrl: '', // Mock Data
     }
   }
 }

--- a/src/views/TripView.vue
+++ b/src/views/TripView.vue
@@ -89,12 +89,11 @@ import TripCard from '@/components/trip/TripCard.vue'
 import TripDetailModal from '@/components/modal/TripDetailModal.vue'
 import ScrollToTop from '@/components/common/ScrollToTop.vue'
 import { useRouter } from 'vue-router'
-import { createTrip, getMyTrips } from '@/services/trip'
-import { TripResponseDto, TripStatus } from '@/types/trip'
+import { createTrip, getMyTrips, getTripDetail } from '@/services/trip' // Added getTripDetail
+import { TripResponseDto, TripStatus, TripDetailResponseDto } from '@/types/trip' // Added TripDetailResponseDto
 
 // TODO: TripCard에서 필요한 spots, tags, spotPreviews, completedDate 필드가 TripResponseDto에 없음.
-// 현재는 TripResponseDto를 기반으로 하되, TripCard에 필요한 필드는 임시로 처리하거나,
-// TripCard의 props 타입을 TripResponseDto에 맞게 조정해야 합니다.
+// 현재는 TripResponseDto를 기반으로 하되, TripCard의 props 타입을 TripResponseDto에 맞게 조정해야 합니다.
 // 장기적으로는 백엔드 API에서 해당 정보를 제공하거나, TripCard 컴포넌트의 요구사항을 조정해야 합니다.
 
 const { handleNavigate } = useNavigate()
@@ -114,7 +113,7 @@ onMounted(async () => {
   }
 })
 
-const selectedTrip = ref<any>(null)
+const selectedTrip = ref<TripDetailResponseDto | null>(null) // Changed type to TripDetailResponseDto | null
 
 // 새로운 여행 계획 생성 핸들러
 const handleCreateNewTrip = async () => {
@@ -187,16 +186,24 @@ const formatMonth = (monthStr: string) => {
 // --- 핸들러 함수들 ---
 
 // 1. 모달 열기 로직
-const handleOpenModal = (tripId: number) => {
-  const trip = tripsList.value.find((t) => t.id === tripId)
-  if (trip) {
+const handleOpenModal = async (tripId: number) => { // Made async
+  try {
+    const detail = await getTripDetail(tripId) // Fetch detailed trip data
     selectedTrip.value = {
-      ...trip,
+      ...detail,
+      // description은 tripItems에서 파생
+      description: detail.tripItems && detail.tripItems.length > 0
+        ? detail.tripItems.map((item) => item.spot.name).join(' → ')
+        : '장소 없음',
+      // duration, views, imageUrl은 TripDetailResponseDto에 없으므로 mock data 유지 또는 제거
       duration: '반나절', // Mock Data
-      description: trip.spotPreviews && trip.spotPreviews.length > 0 ? trip.spotPreviews.map((s) => s.name).join(' → ') : '장소 없음',
       views: 1240, // Mock Data
       imageUrl: '', // Mock Data
     }
+  } catch (error) {
+    console.error(`여행 상세 조회 실패 (ID: ${tripId}):`, error)
+    alert('여행 상세 정보를 불러오는데 실패했습니다.')
+    selectedTrip.value = null // 모달을 열지 않음
   }
 }
 


### PR DESCRIPTION
## Issue
- #15 


## Details
<img width="500" height="" alt="image" src="https://github.com/user-attachments/assets/2ddf0656-0ff1-477d-9008-3ad179d2559e" />

<img width="300" height="" alt="image" src="https://github.com/user-attachments/assets/d91b8602-c59d-446f-b207-db588faecc7a" />


이제 목업 데이터를 사용하지 않고 실제 db에서 유저의 여행 계획을 불러옵니다.

### 향후계획
UI를 리팩토링하려 합니다.

<img width="300" height="" alt="image" src="https://github.com/user-attachments/assets/f7d94500-ba8d-49fa-a59f-58e61bc43862" />

현재는 장소를 클릭하면 장소 모달을 띄워줍니다. 지도에서의 위치를 확인할 수 없습니다. 따라서 지도에 장소 번호를 연동하고 클릭하면 지도의 마커가 확대되며 지도 아래에 패널로 상세정보를  띄워주게 하고 싶습니다.