### PR TITLE
feat: 여행 계획 페이지 장소 상세 보기 UI 변경 및 완료 카드 월별 구분 추가

### DIFF
--- a/src/components/modal/TripDetailModal.vue
+++ b/src/components/modal/TripDetailModal.vue
@@ -209,8 +209,31 @@ const handleEditClick = () => {
 const handlePlaceClick = (place: SpotResponseDto) => {
   selectedPlace.value = place
   selectedMarkerId.value = place.id
-  if (place.lat && place.lng) {
-    kakaoMapRef.value?.panTo(place.lat, place.lng)
+  if (place.lat && place.lng && kakaoMapRef.value) {
+    let finalLat = place.lat
+
+    const map = kakaoMapRef.value.map
+    if (!map) {
+      kakaoMapRef.value.panTo(place.lat, place.lng)
+      return
+    }
+
+    const bounds = map.getBounds()
+    const mapDiv = kakaoMapRef.value.$el
+
+    if (bounds && mapDiv && mapDiv.offsetHeight > 0) {
+      const mapHeightInPixels = mapDiv.offsetHeight
+      // 패널 높이(256px)의 약 1/3인 85px을 오프셋으로 사용
+      const pixelOffset = 85
+
+      const latSpan = bounds.getNorthEast().getLat() - bounds.getSouthWest().getLat()
+      const latOffset = (latSpan / mapHeightInPixels) * pixelOffset
+
+      // 중심을 아래로 이동시켜 마커가 패널 위로 보이게 함
+      finalLat -= latOffset
+    }
+
+    kakaoMapRef.value.panTo(finalLat, place.lng)
   }
 }
 

--- a/src/components/trip/PlaceDetailPanel.vue
+++ b/src/components/trip/PlaceDetailPanel.vue
@@ -31,15 +31,15 @@
             <MapPin :size="14" class="flex-shrink-0" />
             <span class="truncate">{{ place.address }}</span>
           </div>
-          <div v-if="place.url" class="flex items-center gap-2 font-bold">
+          <div v-if="place.placeUrl" class="flex items-center gap-2 font-bold">
             <Globe :size="14" class="flex-shrink-0" />
             <a
-              :href="place.url"
+              :href="place.placeUrl"
               target="_blank"
               class="truncate text-blue-600 hover:underline"
               @click.stop
             >
-              {{ place.url }}
+              {{ place.placeUrl }}
             </a>
           </div>
         </div>

--- a/src/composables/trip/useMapInteraction.ts
+++ b/src/composables/trip/useMapInteraction.ts
@@ -63,7 +63,12 @@ export function useMapInteraction({
   // --- Actions ---
 
   // 1. 장소/마커 클릭 시 처리 (지도 이동 & 강조)
-  const selectAndPanToPlace = (id: number | string, lat?: number, lng?: number) => {
+  const selectAndPanToPlace = (
+    id: number | string,
+    lat?: number,
+    lng?: number,
+    options?: { panWithOffset?: boolean }
+  ) => {
     selectedMarkerId.value = id
 
     // 좌표가 인자로 안 들어왔으면(마커 클릭 시), 리스트에서 찾음
@@ -72,7 +77,9 @@ export function useMapInteraction({
 
     if (targetLat === undefined || targetLng === undefined) {
       // id가 tripItemId일 수도, kakaoPlaceId일 수도 있으므로 둘 다 비교
-      const target = markerPositions.value.find((m) => String(m.id) === String(id) || String(m.kakaoPlaceId) === String(id))
+      const target = markerPositions.value.find(
+        (m) => String(m.id) === String(id) || String(m.kakaoPlaceId) === String(id)
+      )
       if (target) {
         targetLat = target.lat
         targetLng = target.lng
@@ -80,19 +87,38 @@ export function useMapInteraction({
     }
 
     if (targetLat !== undefined && targetLng !== undefined && kakaoMapRef.value?.panTo) {
-      kakaoMapRef.value.panTo(targetLat, targetLng)
+      let finalLat = targetLat
+
+      // panWithOffset 옵션이 true일 경우, 지도 중심을 아래로 이동시켜 마커가 위쪽에 표시되도록 함
+      if (options?.panWithOffset) {
+        const map = kakaoMapRef.value.getMap()
+        const bounds = map.getBounds()
+        const mapDiv = kakaoMapRef.value.$el
+
+        if (bounds && mapDiv) {
+          const mapHeightInPixels = mapDiv.offsetHeight
+          const panelHeightInPixels = 256 // PlaceDetailPanel의 높이 (h-64 = 16rem = 256px)
+          const pixelOffset = panelHeightInPixels / 2
+
+          const latSpan = bounds.getNorthEast().getLat() - bounds.getSouthWest().getLat()
+          const latOffset = (latSpan / mapHeightInPixels) * pixelOffset
+
+          finalLat -= latOffset // 중심을 아래로 이동 (마커가 위로 올라와 보임)
+        }
+      }
+      kakaoMapRef.value.panTo(finalLat, targetLng)
     }
   }
 
   // 2. 리스트에서 카드 클릭 핸들러
-  const handlePlaceClick = (place: Place) => {
+  const handlePlaceClick = (place: Place, options?: { panWithOffset?: boolean }) => {
     // place.id (tripItemId)가 있으면 그걸 사용하고, 없으면 kakaoPlaceId 사용
-    selectAndPanToPlace(place.id || place.kakaoPlaceId, place.lat, place.lng)
+    selectAndPanToPlace(place.id || place.kakaoPlaceId, place.lat, place.lng, options)
   }
 
   // 3. 지도 마커 클릭 핸들러
-  const handleMarkerClick = (id: number | string) => {
-    selectAndPanToPlace(id)
+  const handleMarkerClick = (id: number | string, options?: { panWithOffset?: boolean }) => {
+    selectAndPanToPlace(id, undefined, undefined, options)
   }
 
   // 4. 지도 움직임 감지

--- a/src/composables/trip/useMapInteraction.ts
+++ b/src/composables/trip/useMapInteraction.ts
@@ -91,14 +91,19 @@ export function useMapInteraction({
 
       // panWithOffset 옵션이 true일 경우, 지도 중심을 아래로 이동시켜 마커가 위쪽에 표시되도록 함
       if (options?.panWithOffset) {
-        const map = kakaoMapRef.value.getMap()
+        const map = kakaoMapRef.value.map
+        if (!map) {
+          kakaoMapRef.value.panTo(targetLat, targetLng)
+          return
+        }
+
         const bounds = map.getBounds()
         const mapDiv = kakaoMapRef.value.$el
 
-        if (bounds && mapDiv) {
+        if (bounds && mapDiv && mapDiv.offsetHeight > 0) {
           const mapHeightInPixels = mapDiv.offsetHeight
-          const panelHeightInPixels = 256 // PlaceDetailPanel의 높이 (h-64 = 16rem = 256px)
-          const pixelOffset = panelHeightInPixels / 2
+          // 패널 높이(256px)의 약 1/3인 85px을 오프셋으로 사용
+          const pixelOffset = 85
 
           const latSpan = bounds.getNorthEast().getLat() - bounds.getSouthWest().getLat()
           const latOffset = (latSpan / mapHeightInPixels) * pixelOffset

--- a/src/composables/trip/usePlaceSearch.ts
+++ b/src/composables/trip/usePlaceSearch.ts
@@ -43,7 +43,7 @@ export function usePlaceSearch() {
             lat: Number(item.y),
             lng: Number(item.x),
             phone: item.phone,
-            url: item.place_url,
+            placeUrl: item.place_url,
           }))
         } else if (status === (window as any).kakao.maps.services.Status.ZERO_RESULT) {
           searchResults.value = []

--- a/src/composables/trip/useTripPlan.ts
+++ b/src/composables/trip/useTripPlan.ts
@@ -30,7 +30,7 @@ const mapTripItemToPlace = (item: TripItemResponseDto): Place => ({
   category: item.spot.category,
   lat: item.spot.lat,
   lng: item.spot.lng,
-  url: item.spot.placeUrl,
+  placeUrl: item.spot.placeUrl,
   memo: item.memo,
 })
 
@@ -129,7 +129,7 @@ export function useTripPlan() {
                   category: place.category,
                   lat: place.lat,
                   lng: place.lng,
-                  placeUrl: place.url || '',
+                  placeUrl: place.placeUrl || '',
                 },
                 memo: place.memo,
               }
@@ -210,7 +210,13 @@ export function useTripPlan() {
       return
     }
 
-    const newPlace = { ...place, id: undefined, memo: '' }
+    // placeUrl을 명시적으로 복사하여 데이터 유실을 방지합니다.
+    const newPlace: Place = {
+      ...place,
+      placeUrl: place.placeUrl,
+      id: undefined,
+      memo: '',
+    }
     day.places.push(newPlace)
     return newPlace
   }

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -9,27 +9,7 @@ export interface Place {
   lat: number
   lng: number
   phone?: string
-  url?: string
-  memo?: string // 아이템 메모
-}
-
-export interface DayPlan {
-  dayNumber: number
-  places: Place[]
-}
-
-// src/types/trip.ts
-
-export interface Place {
-  id?: number // 동기화 전에는 id가 없을 수 있음 (tripItemId)
-  kakaoPlaceId: string // 장소의 고유 카카오 ID
-  name: string
-  address: string
-  category: string
-  lat: number
-  lng: number
-  phone?: string
-  url?: string
+  placeUrl?: string
   memo?: string // 아이템 메모
 }
 

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -10,7 +10,7 @@
             class="text-5xl font-black tracking-tighter uppercase"
             style="font-family: 'Outfit', sans-serif"
           >
-            Discover <span class="italic text-[#9BCCC4]">Places</span>
+            Discover <span class="text-[#9BCCC4]">Places</span>
           </h2>
         </div>
 
@@ -331,7 +331,7 @@
           class="text-5xl mb-6 font-black tracking-tighter uppercase"
           style="font-family: 'Outfit', sans-serif"
         >
-          Hot Place <span class="italic text-[#E88555]">Top 10</span>
+          Hot Place <span class="text-[#E88555]">Top 10</span>
         </h2>
 
         <div class="space-y-4">

--- a/src/views/TripPlanView.vue
+++ b/src/views/TripPlanView.vue
@@ -32,7 +32,7 @@
         @remove-day="trip.removeDay"
         @remove-place="trip.removePlace"
         @update-places="trip.updatePlaces"
-        @click-place="mapInteraction.handlePlaceClick"
+        @click-place="showDetailAndPan"
       />
 
       <div
@@ -53,44 +53,53 @@
         :selected-id="mapInteraction.selectedMarkerId.value"
         @close="closeSearchPanel"
         @add-place="handleAddPlace"
-        @click-item="mapInteraction.handlePlaceClick"
+        @click-item="showDetailAndPan"
       />
 
-      <div class="flex-1 bg-gray-100 relative z-0">
-        <KakaoMap
-          ref="kakaoMapRef"
-          class="absolute inset-0"
-          :center="{ lat: 37.5443, lng: 127.0557 }"
-          :level="5"
-          :markers="mapInteraction.markerPositions.value"
-          :selected-marker-id="mapInteraction.selectedMarkerId.value"
-          @marker-click="mapInteraction.handleMarkerClick"
-          @map-move="mapInteraction.onMapMove"
-        />
+      <div class="flex-1 flex flex-col bg-gray-100">
+        <div class="flex-1 relative">
+          <KakaoMap
+            ref="kakaoMapRef"
+            class="absolute inset-0"
+            :center="{ lat: 37.5443, lng: 127.0557 }"
+            :level="5"
+            :markers="mapInteraction.markerPositions.value"
+            :selected-marker-id="mapInteraction.selectedMarkerId.value"
+            @marker-click="showDetailAndPanFromMarker"
+            @map-move="mapInteraction.onMapMove"
+          />
 
-        <div
-          v-if="mapInteraction.showReSearchButton.value"
-          class="absolute top-6 left-1/2 -translate-x-1/2 z-20 animate-fade-in-up"
-        >
-          <button
-            @click="mapInteraction.triggerSearch"
-            class="flex items-center gap-2 px-4 py-2.5 bg-white border-[2px] border-[#2C2C2C] rounded-full shadow-[0_4px_10px_rgba(0,0,0,0.15)] hover:bg-gray-50 active:scale-95 transition-all text-xs font-black text-[#2C2C2C]"
+          <div
+            v-if="mapInteraction.showReSearchButton.value"
+            class="absolute top-6 left-1/2 -translate-x-1/2 z-20 animate-fade-in-up"
           >
-            <RotateCw class="w-3.5 h-3.5" stroke-width="2.5" />
-            현 지도에서 재검색
-          </button>
+            <button
+              @click="mapInteraction.triggerSearch"
+              class="flex items-center gap-2 px-4 py-2.5 bg-white border-[2px] border-[#2C2C2C] rounded-full shadow-[0_4px_10px_rgba(0,0,0,0.15)] hover:bg-gray-50 active:scale-95 transition-all text-xs font-black text-[#2C2C2C]"
+            >
+              <RotateCw class="w-3.5 h-3.5" stroke-width="2.5" />
+              현 지도에서 재검색
+            </button>
+          </div>
         </div>
+
+        <PlaceDetailPanel
+          :place="selectedPlaceForDetail"
+          @close="selectedPlaceForDetail = null"
+        />
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue'
 import { RotateCw } from 'lucide-vue-next'
 import KakaoMap from '@/components/common/KakaoMap.vue'
 import TripPlanHeader from '@/components/trip/TripPlanHeader.vue'
 import TripPlanPanel from '@/components/trip/TripPlanPanel.vue'
 import TripSearchListPanel from '@/components/trip/TripSearchListPanel.vue'
+import PlaceDetailPanel from '@/components/trip/PlaceDetailPanel.vue'
 import type { Place } from '@/types/trip'
 
 // Import Composables
@@ -134,17 +143,46 @@ const mapInteraction = useMapInteraction({
 // 단, ref="kakaoMapRef" 연결을 위해 이것만 별도로 꺼내줍니다.
 const { kakaoMapRef } = mapInteraction
 
+const selectedPlaceForDetail = ref<Place | null>(null)
+
+// Helper to find a place from any list by its ID (trip item ID or kakaoPlaceId)
+const findPlaceById = (id: number | string): Place | undefined => {
+  // Combine search results and all planned places into one array
+  const allPlaces = [...searchResults.value, ...trip.allSelectedPlaces.value]
+  // Find the place that matches either the trip item ID or the Kakao Place ID
+  return allPlaces.find((p) => p.id === id || p.kakaoPlaceId === id)
+}
+
+// Wrapper for place/item clicks to show detail panel and pan map with offset
+const showDetailAndPan = (place: Place) => {
+  selectedPlaceForDetail.value = place
+  mapInteraction.handlePlaceClick(place, { panWithOffset: true })
+}
+
+// Wrapper for marker clicks to find place data, show panel, and pan map with offset
+const showDetailAndPanFromMarker = (id: number | string) => {
+  const place = findPlaceById(id)
+  if (place) {
+    selectedPlaceForDetail.value = place
+    mapInteraction.handleMarkerClick(id, { panWithOffset: true })
+  } else {
+    // If place is not found (e.g., from a different day), just pan without detail
+    mapInteraction.handleMarkerClick(id)
+  }
+}
+
 const handleAddPlace = (place: Place) => {
   const newPlace = trip.addPlace(place)
   if (newPlace) {
-    mapInteraction.handlePlaceClick(newPlace)
+    // 추가된 장소는 바로 패널을 띄우고 중심으로 이동
+    showDetailAndPan(newPlace)
   }
 }
 
 // 저장/뒤로가기 연결
 const tripSave = () => {
-  console.log('tripSave called');
-  trip.saveTrip(closeSearchPanel);
+  console.log('tripSave called')
+  trip.saveTrip(closeSearchPanel)
 }
 const tripBack = () => trip.goBack(closeSearchPanel)
 </script>

--- a/src/views/TripView.vue
+++ b/src/views/TripView.vue
@@ -24,7 +24,7 @@
         <button
           v-for="tab in tabs"
           :key="tab.id"
-          @click="activeTab = tab.id as any"
+          @click="activeTab = tab.id"
           :class="[
             'px-3 py-1.5 rounded-lg transition-all text-xs font-bold whitespace-nowrap focus:outline-none border-[2px] border-transparent',
             activeTab === tab.id
@@ -36,7 +36,7 @@
         </button>
       </div>
 
-      <div v-if="activeTab === 'completed'" class="space-y-12">
+      <div v-if="activeTab === TripStatus.COMPLETED" class="space-y-12">
         <div v-for="(group, month) in groupedCompletedTrips" :key="month">
           <div class="mb-6">
             <h2 class="text-5xl font-black tracking-tighter uppercase font-sans text-black">
@@ -99,7 +99,7 @@ import { TripResponseDto, TripStatus, TripDetailResponseDto } from '@/types/trip
 const { handleNavigate } = useNavigate()
 const router = useRouter()
 
-const activeTab = ref<'all' | 'PLANNED' | 'COMPLETED' | 'saved'>('all') // Changed to use TripStatus enum values
+const activeTab = ref<TripStatus | 'all' | 'saved'>('all')
 const tripsList = ref<TripResponseDto[]>([]) // Changed to TripResponseDto[]
 
 onMounted(async () => {
@@ -134,26 +134,26 @@ const savedTrips = computed(() => tripsList.value.filter((t) => t.status === '�
 
 const displayTrips = computed(() => {
   const filteredTrips = (() => {
-    if (activeTab.value === 'PLANNED') return planningTrips.value
-    if (activeTab.value === 'COMPLETED') return completedTrips.value
+    if (activeTab.value === TripStatus.PLANNED) return planningTrips.value
+    if (activeTab.value === TripStatus.COMPLETED) return completedTrips.value
     if (activeTab.value === 'saved') return savedTrips.value
     return tripsList.value
-  })();
-  console.log('displayTrips:', filteredTrips); // Added log
-  return filteredTrips;
+  })()
+  console.log('displayTrips:', filteredTrips) // Added log
+  return filteredTrips
 })
 
 const tabs = [
   { id: 'all', label: '전체' },
-  { id: 'PLANNED', label: '계획중' }, // Changed to PLANNED
-  { id: 'COMPLETED', label: '완료' }, // Changed to COMPLETED
+  { id: TripStatus.PLANNED, label: '계획중' },
+  { id: TripStatus.COMPLETED, label: '완료' },
   { id: 'saved', label: '스크랩' },
 ]
 
-const getCount = (tabId: string) => {
+const getCount = (tabId: TripStatus | 'all' | 'saved') => {
   if (tabId === 'all') return tripsList.value.length
-  if (tabId === 'PLANNED') return planningTrips.value.length
-  if (tabId === 'COMPLETED') return completedTrips.value.length
+  if (tabId === TripStatus.PLANNED) return planningTrips.value.length
+  if (tabId === TripStatus.COMPLETED) return completedTrips.value.length
   if (tabId === 'saved') return savedTrips.value.length
   return 0
 }
@@ -161,8 +161,8 @@ const getCount = (tabId: string) => {
 const groupedCompletedTrips = computed(() => {
   const groups: Record<string, TripResponseDto[]> = {} // Changed to TripResponseDto[]
   completedTrips.value.forEach((trip) => {
-    if (trip.completedDate) {
-      const monthKey = trip.completedDate.substring(0, 7)
+    if (trip.startDate) {
+      const monthKey = trip.startDate.substring(0, 7)
       if (!groups[monthKey]) groups[monthKey] = []
       groups[monthKey].push(trip)
     }
@@ -179,22 +179,24 @@ const groupedCompletedTrips = computed(() => {
 })
 
 const formatMonth = (monthStr: string) => {
-  const [year, month] = monthStr.split('.')
+  const [year, month] = monthStr.split('-')
   return { year, month }
 }
 
 // --- 핸들러 함수들 ---
 
 // 1. 모달 열기 로직
-const handleOpenModal = async (tripId: number) => { // Made async
+const handleOpenModal = async (tripId: number) => {
+  // Made async
   try {
     const detail = await getTripDetail(tripId) // Fetch detailed trip data
     selectedTrip.value = {
       ...detail,
       // description은 tripItems에서 파생
-      description: detail.tripItems && detail.tripItems.length > 0
-        ? detail.tripItems.map((item) => item.spot.name).join(' → ')
-        : '장소 없음',
+      description:
+        detail.tripItems && detail.tripItems.length > 0
+          ? detail.tripItems.map((item) => item.spot.name).join(' → ')
+          : '장소 없음',
       // duration, views, imageUrl은 TripDetailResponseDto에 없으므로 mock data 유지 또는 제거
       duration: '반나절', // Mock Data
       views: 1240, // Mock Data

--- a/src/views/TripView.vue
+++ b/src/views/TripView.vue
@@ -6,7 +6,7 @@
       <div class="flex flex-col md:flex-row md:items-end justify-between mb-8 gap-4">
         <div>
           <h1 class="text-5xl font-black tracking-tighter uppercase mb-2 font-sans text-black">
-            My <span class="italic text-[#9BCCC4]">Trips</span>
+            My <span class="ml-2 text-[#9BCCC4]">Trips</span>
           </h1>
           <p class="text-sm font-bold text-gray-600">나만의 여행 계획을 만들고 관리하세요</p>
         </div>
@@ -40,7 +40,7 @@
         <div v-for="(group, month) in groupedCompletedTrips" :key="month">
           <div class="mb-6">
             <h2 class="text-5xl font-black tracking-tighter uppercase font-sans text-black">
-              {{ formatMonth(month as string).year }}.<span class="italic text-[#E88555]">{{
+              {{ formatMonth(month as string).year }}.<span class="text-[#E88555]">{{
                 formatMonth(month as string).month
               }}</span>
             </h2>


### PR DESCRIPTION
## Issue
- #15 

## Details

<img width="500" height="" alt="image" src="https://github.com/user-attachments/assets/032d2c16-5476-4dc6-88d5-1414b49059d0" />

<img width="500" height="" alt="image" src="https://github.com/user-attachments/assets/c85e09af-9bd2-4db9-b5bc-b63db6580f3c" />

<img width="500" height="" alt="image" src="https://github.com/user-attachments/assets/3e258d5a-6b98-4aa6-8c73-166ceb840796" />

여행 계획 카드에서  장소 클릭 시 새로운 모달이 아니라 지도 아래 패널로 상세 정보가 나오도록 변경했습니다.
여행 계획 세우기 페이지에도 똑같은 ui를 적용했습니다.
여행 완료 카드들은 월별로 구분감 있게 보여지도록 했습니다.

### 추구 구현해야할 것들
- 장소간 거리
- 장소 메모
- 장소 별점(리뷰) 달기
- 스크랩 기능
- 태그 연동하기