### PR TITLE
feat: 다이어리 댓글 기능 및 UX 개선, 안정성 강화

### DIFF
--- a/src/apis/trip.ts
+++ b/src/apis/trip.ts
@@ -8,6 +8,8 @@ import type {
   TripSummaryResponseDto, // Added
   TripStatus,
   TripLogDetail, // Added
+  TripLogCommentRequest,
+  TripLogCommentResponse,
 } from '@/types/trip'
 
 // API 호출 함수
@@ -95,6 +97,23 @@ export const getMyTripSummaries = async (): Promise<TripSummaryResponseDto[]> =>
  */
 export const getTripLogDetail = async (logId: number): Promise<TripLogDetail> => {
   const response = await apiClient.get<TripLogDetail>(`/trip-logs/${logId}`)
+  return response.data
+}
+
+/**
+ * 여행 기록(로그)에 댓글을 작성합니다.
+ * @param logId 댓글을 작성할 여행 기록의 ID
+ * @param commentData 댓글 내용
+ * @returns 생성된 댓글 정보
+ */
+export const postTripLogComment = async (
+  logId: number,
+  commentData: TripLogCommentRequest,
+): Promise<TripLogCommentResponse> => {
+  const response = await apiClient.post<TripLogCommentResponse>(
+    `/trip-logs/${logId}/comments`,
+    commentData,
+  )
   return response.data
 }
 

--- a/src/components/common/AlertDialog.vue
+++ b/src/components/common/AlertDialog.vue
@@ -1,0 +1,63 @@
+<template>
+  <div
+    v-if="show"
+    class="fixed inset-0 bg-black/60 flex items-center justify-center z-[100] p-4"
+    @click.self="handleClose"
+  >
+    <div
+      class="bg-white border-[3px] border-[#2C2C2C] rounded-2xl shadow-[8px_8px_0px_0px_rgba(44,44,44,0.3)] max-w-sm w-full p-8 text-center"
+    >
+      <h3 class="font-black text-2xl mb-4 text-[#2C2C2C] font-sans">{{ title }}</h3>
+      <p class="text-base font-medium text-gray-700 mb-8 whitespace-pre-line">{{ message }}</p>
+      <div class="flex gap-3 justify-center">
+        <button
+          @click="handleClose"
+          class="px-8 py-3 border-[2px] border-[#2C2C2C] rounded-lg font-black text-sm bg-white text-[#2C2C2C] hover:shadow-[3px_3px_0px_0px_rgba(44,44,44,0.15)] hover:translate-x-[-1px] hover:translate-y-[-1px] transition-all uppercase tracking-wide"
+        >
+          {{ closeButtonText }}
+        </button>
+        <button
+          @click="handleConfirm"
+          class="px-8 py-3 border-[2px] border-[#2C2C2C] rounded-lg font-black text-sm bg-[#F9CA6B] text-[#2C2C2C] hover:shadow-[3px_3px_0px_0px_rgba(44,44,44,0.15)] hover:translate-x-[-1px] hover:translate-y-[-1px] transition-all uppercase tracking-wide"
+        >
+          {{ confirmButtonText }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps({
+  show: {
+    type: Boolean,
+    required: true,
+  },
+  title: {
+    type: String,
+    default: '알림',
+  },
+  message: {
+    type: String,
+    required: true,
+  },
+  confirmButtonText: {
+    type: String,
+    default: '확인',
+  },
+  closeButtonText: {
+    type: String,
+    default: '취소',
+  },
+})
+
+const emit = defineEmits(['close', 'confirm'])
+
+const handleClose = () => {
+  emit('close')
+}
+
+const handleConfirm = () => {
+  emit('confirm')
+}
+</script>

--- a/src/components/common/KakaoMap.vue
+++ b/src/components/common/KakaoMap.vue
@@ -179,8 +179,10 @@ const panTo = (lat: number, lng: number) => {
 watch(
   () => props.selectedMarkerId,
   (newId) => {
+    if (!mapLoaded.value) return // Add guard clause
+
     const kakao = (window as any).kakao
-    if (!kakao) return
+    if (!kakao || !kakao.maps) return
 
     const normalImage = new kakao.maps.MarkerImage(
       DEFAULT_MARKER_SRC,
@@ -242,16 +244,21 @@ const initMap = () => {
 }
 
 onMounted(() => {
-  const kakao = (window as any).kakao
-  if (kakao && kakao.maps) {
-    if (typeof kakao.maps.load === 'function') {
-      kakao.maps.load(() => {
+  const checkKakao = () => {
+    const kakao = (window as any).kakao
+    if (kakao && kakao.maps) {
+      if (typeof kakao.maps.load === 'function') {
+        kakao.maps.load(() => {
+          initMap()
+        })
+      } else {
         initMap()
-      })
+      }
     } else {
-      initMap()
+      setTimeout(checkKakao, 200) // Poll every 200ms
     }
   }
+  checkKakao()
 })
 
 onUnmounted(() => {

--- a/src/components/modal/DiaryCommentModal.vue
+++ b/src/components/modal/DiaryCommentModal.vue
@@ -182,33 +182,33 @@
 
             <!-- Course Content -->
             <div class="pt-3">
-              <div
-                v-for="day in groupedCourse"
-                :key="day.dayNumber"
-                v-show="activeDay === day.dayNumber"
-              >
-                <div class="flex items-center flex-wrap gap-x-1.5 gap-y-2">
-                  <div
-                    v-for="(place, index) in day.places"
-                    :key="index"
-                    class="flex items-center gap-1.5"
-                  >
-                    <div
-                      @click.stop="handleCourseClick(place.id)"
-                      class="flex items-center gap-1 px-2.5 py-1 border-[2px] border-[#2C2C2C] rounded-full bg-white shadow-[1px_1px_0px_0px_rgba(44,44,44,0.1)] course-badge cursor-pointer"
-                      :style="{ '--hover-color': getBadgeColor(index) }"
-                    >
-                      <span class="text-xs font-black text-[#2C2C2C]">{{ index + 1 }}</span>
-                      <span class="text-xs font-black text-[#2C2C2C] whitespace-nowrap">{{
-                        place.name
-                      }}</span>
+              <div v-for="day in groupedCourse" :key="day.dayNumber">
+                <Transition name="no-animation">
+                  <div v-show="activeDay === day.dayNumber">
+                    <div class="flex items-center flex-wrap gap-x-1.5 gap-y-2">
+                      <div
+                        v-for="(place, index) in day.places"
+                        :key="index"
+                        class="flex items-center gap-1.5"
+                      >
+                        <div
+                          @click.stop="handleCourseClick(place.id)"
+                          class="flex items-center gap-1 px-2.5 py-1 border-[2px] border-[#2C2C2C] rounded-full bg-white shadow-[1px_1px_0px_0px_rgba(44,44,44,0.1)] course-badge cursor-pointer"
+                          :style="{ '--hover-color': getBadgeColor(index) }"
+                        >
+                          <span class="text-xs font-black text-[#2C2C2C]">{{ index + 1 }}</span>
+                          <span class="text-xs font-black text-[#2C2C2C] whitespace-nowrap">{{
+                            place.name
+                          }}</span>
+                        </div>
+                        <ChevronRight
+                          v-if="index < day.places.length - 1"
+                          class="w-3 h-3 text-gray-400 flex-shrink-0"
+                        />
+                      </div>
                     </div>
-                    <ChevronRight
-                      v-if="index < day.places.length - 1"
-                      class="w-3 h-3 text-gray-400 flex-shrink-0"
-                    />
                   </div>
-                </div>
+                </Transition>
               </div>
             </div>
           </div>
@@ -266,20 +266,52 @@
             </button>
           </div>
 
-          <form @submit.prevent="handleCommentSubmit" class="p-4 pt-0 flex items-center gap-2.5">
-            <input
-              v-model="newComment"
-              type="text"
-              placeholder="댓글을 입력하세요..."
-              class="flex-1 px-4 py-3 border-[2px] border-[#2C2C2C] rounded-lg text-sm font-medium bg-white focus:outline-none focus:shadow-[2px_2px_0px_0px_rgba(107,143,212,0.3)] transition-all placeholder:text-gray-400"
-            />
-            <button
-              type="submit"
-              class="px-5 py-3 border-[2px] border-[#2C2C2C] rounded-lg font-black text-xs bg-[#F9CA6B] text-[#2C2C2C] hover:shadow-[3px_3px_0px_0px_rgba(44,44,44,0.15)] hover:translate-x-[-1px] hover:translate-y-[-1px] transition-all uppercase tracking-wide"
-            >
-              작성
-            </button>
-          </form>
+          <div class="p-4 pt-0">
+            <form @submit.prevent="handleCommentSubmit" class="flex items-center gap-2.5">
+              <div
+                class="w-10 h-10 border-[2px] border-[#2C2C2C] rounded-full overflow-hidden flex-shrink-0 shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]"
+              >
+                <img
+                  v-if="authStore.isLoggedIn && authStore.user?.profileImageUrl"
+                  :src="authStore.user.profileImageUrl"
+                  alt="My Profile"
+                  class="w-full h-full object-cover"
+                />
+                <img
+                  v-else
+                  src="/default-profile.svg"
+                  alt="Default Profile"
+                  class="w-full h-full object-cover"
+                />
+              </div>
+              <div class="relative flex-1">
+                <input
+                  v-model="newComment"
+                  :disabled="!authStore.isLoggedIn"
+                  type="text"
+                  :placeholder="
+                    authStore.isLoggedIn ? '댓글을 입력하세요...' : '로그인 후 댓글을 남길 수 있습니다.'
+                  "
+                  :class="[
+                    'w-full px-4 py-3 border-[2px] border-[#2C2C2C] rounded-lg text-sm font-medium bg-white focus:outline-none focus:shadow-[2px_2px_0px_0px_rgba(107,143,212,0.3)] transition-all placeholder:text-gray-400',
+                    !authStore.isLoggedIn ? 'bg-gray-100' : '',
+                  ]"
+                />
+                <div
+                  v-if="!authStore.isLoggedIn"
+                  @click="handleCommentInputClick"
+                  class="absolute inset-0 cursor-pointer"
+                ></div>
+              </div>
+              <button
+                type="submit"
+                :disabled="!authStore.isLoggedIn"
+                class="px-5 py-3 border-[2px] border-[#2C2C2C] rounded-lg font-black text-xs bg-[#F9CA6B] text-[#2C2C2C] hover:shadow-[3px_3px_0px_0px_rgba(44,44,44,0.15)] hover:translate-x-[-1px] hover:translate-y-[-1px] transition-all uppercase tracking-wide disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                작성
+              </button>
+            </form>
+          </div>
         </div>
       </div>
     </div>
@@ -465,6 +497,12 @@ const handleCommentSubmit = async () => {
   }
 }
 
+const handleCommentInputClick = () => {
+  if (!authStore.isLoggedIn) {
+    isLoginAlertVisible.value = true
+  }
+}
+
 const handleLoginConfirm = () => {
   isLoginAlertVisible.value = false
   router.push({ name: 'login' })
@@ -537,6 +575,11 @@ const formatCommentDate = (dateString: string) => {
 <style scoped>
 .course-badge:hover {
   background-color: var(--hover-color);
+}
+
+.no-animation-enter-active,
+.no-animation-leave-active {
+  transition: none;
 }
 </style>
 

--- a/src/components/modal/DiaryCommentModal.vue
+++ b/src/components/modal/DiaryCommentModal.vue
@@ -266,18 +266,20 @@
             </button>
           </div>
 
-          <div class="p-4 pt-0 flex items-center gap-2.5">
+          <form @submit.prevent="handleCommentSubmit" class="p-4 pt-0 flex items-center gap-2.5">
             <input
+              v-model="newComment"
               type="text"
               placeholder="댓글을 입력하세요..."
               class="flex-1 px-4 py-3 border-[2px] border-[#2C2C2C] rounded-lg text-sm font-medium bg-white focus:outline-none focus:shadow-[2px_2px_0px_0px_rgba(107,143,212,0.3)] transition-all placeholder:text-gray-400"
             />
             <button
+              type="submit"
               class="px-5 py-3 border-[2px] border-[#2C2C2C] rounded-lg font-black text-xs bg-[#F9CA6B] text-[#2C2C2C] hover:shadow-[3px_3px_0px_0px_rgba(44,44,44,0.15)] hover:translate-x-[-1px] hover:translate-y-[-1px] transition-all uppercase tracking-wide"
             >
               작성
             </button>
-          </div>
+          </form>
         </div>
       </div>
     </div>
@@ -288,11 +290,22 @@
       :initial-place-id="initialSelectedPlaceId"
       @close="isTripDetailModalVisible = false"
     />
+
+    <AlertDialog
+      :show="isLoginAlertVisible"
+      title="로그인 필요"
+      message="로그인 후 이용해주세요!"
+      confirm-button-text="로그인"
+      close-button-text="취소"
+      @close="isLoginAlertVisible = false"
+      @confirm="handleLoginConfirm"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watchEffect } from 'vue'
+import { useRouter } from 'vue-router'
 import {
   Heart,
   Bookmark,
@@ -304,23 +317,22 @@ import {
   Share,
   Edit,
   Trash2,
-  Link,
 } from 'lucide-vue-next'
-import { getTripLogDetail, getTripDetail } from '@/apis/trip'
-import type { TripLogDetail, TripLogComment, TripDetailResponseDto } from '@/types/trip'
+import { getTripLogDetail, getTripDetail, postTripLogComment } from '@/apis/trip'
+import type { TripLogDetail, TripDetailResponseDto } from '@/types/trip'
 import { format, parseISO } from 'date-fns'
 import TripDetailModal from './TripDetailModal.vue'
-
-interface CourseItem {
-  number: number
-  name: string
-}
+import AlertDialog from '@/components/common/AlertDialog.vue'
+import { useAuthStore } from '@/stores/auth'
 
 const props = defineProps<{
   logId: number
 }>()
 
 const emit = defineEmits(['close'])
+
+const router = useRouter()
+const authStore = useAuthStore()
 
 const logDetail = ref<TripLogDetail | null>(null)
 const tripDetail = ref<TripDetailResponseDto | null>(null)
@@ -335,9 +347,11 @@ const showToast = ref(false)
 const isTripDetailModalVisible = ref(false)
 const activeDay = ref(1)
 const initialSelectedPlaceId = ref<number | null>(null)
+const newComment = ref('')
+const isLoginAlertVisible = ref(false)
 
 // 데이터 로드
-onMounted(async () => {
+const fetchLogDetail = async () => {
   try {
     isLoading.value = true
     logDetail.value = await getTripLogDetail(props.logId)
@@ -347,7 +361,9 @@ onMounted(async () => {
   } finally {
     isLoading.value = false
   }
-})
+}
+
+onMounted(fetchLogDetail)
 
 watchEffect(async () => {
   if (logDetail.value?.tripId) {
@@ -355,12 +371,10 @@ watchEffect(async () => {
       tripDetail.value = await getTripDetail(logDetail.value.tripId)
     } catch (e) {
       console.error('Failed to fetch trip detail:', e)
-      // tripDetail을 못가져와도 로그 자체는 보여줘야 하므로 에러를 크게 표시하지 않음
     }
   }
 })
 
-// 본인 여부 확인 (임시 로직, 추후 실제 유저 정보와 비교해야 함)
 const isAuthor = computed(() => logDetail.value?.authorNickname === '김민준')
 
 const sortedImages = computed(() => {
@@ -375,7 +389,6 @@ const formattedDate = computed(() => {
 
 const formattedContent = computed(() => {
   if (!logDetail.value?.content) return ''
-  // {{img_...}} 형식의 이미지 플레이스홀더가 포함된 줄 전체를 제거합니다.
   return logDetail.value.content.replace(/^[ \t]*{{\s*img_.*?\s*}}[ \t]*$\r?\n?/gm, '')
 })
 
@@ -389,7 +402,6 @@ const groupedCourse = computed(() => {
       if (!acc[day]) {
         acc[day] = { dayNumber: day, places: [] }
       }
-      // place에 id를 포함시켜서 전달
       acc[day].places.push({ id: item.spot.id, name: item.spot.name })
       return acc
     },
@@ -412,48 +424,76 @@ const handleCourseClick = (placeId: number) => {
 const handlePrevImage = () => {
   if (!logDetail.value) return
   currentImageIndex.value =
-    currentImageIndex.value > 0 ? currentImageIndex.value - 1 : logDetail.value.images.length - 1
+    currentImageIndex.value > 0 ? currentImageIndex.value - 1 : sortedImages.value.length - 1
 }
-
 
 const handleNextImage = () => {
   if (!logDetail.value) return
   currentImageIndex.value =
-    currentImageIndex.value < logDetail.value.images.length - 1 ? currentImageIndex.value + 1 : 0
+    currentImageIndex.value < sortedImages.value.length - 1 ? currentImageIndex.value + 1 : 0
 }
 
 const currentLikes = ref(logDetail.value?.likeCount ?? 0)
 const handleLike = () => {
+  if (!authStore.isLoggedIn) {
+    isLoginAlertVisible.value = true
+    return
+  }
   if (isLiked.value) currentLikes.value--
   else currentLikes.value++
   isLiked.value = !isLiked.value
 }
 
-// 드롭다운 메뉴 핸들러
+const handleCommentSubmit = async () => {
+  if (!authStore.isLoggedIn) {
+    isLoginAlertVisible.value = true
+    return
+  }
+  if (!newComment.value.trim()) return
+  try {
+    await postTripLogComment(props.logId, { content: newComment.value })
+    newComment.value = ''
+    // 댓글 목록 갱신
+    const updatedLogDetail = await getTripLogDetail(props.logId)
+    if (logDetail.value) {
+      logDetail.value.comments = updatedLogDetail.comments
+      logDetail.value.commentCount = updatedLogDetail.commentCount
+    }
+  } catch (error) {
+    console.error('Failed to post comment:', error)
+    alert('댓글 작성에 실패했습니다.')
+  }
+}
+
+const handleLoginConfirm = () => {
+  isLoginAlertVisible.value = false
+  router.push({ name: 'login' })
+  emit('close') // Close the main modal as well
+}
+
 const handleShare = () => {
   showDropdown.value = false
-  console.log('공유하기')
-  // TODO: 공유 기능 구현
+  navigator.clipboard.writeText(window.location.href).then(() => {
+    showToast.value = true
+    setTimeout(() => (showToast.value = false), 2000)
+  })
 }
 
 const handleEdit = () => {
   showDropdown.value = false
   console.log('수정하기')
-  // TODO: 수정 기능 구현
 }
 
 const handleDelete = () => {
   showDropdown.value = false
   if (confirm('정말 삭제하시겠습니까?')) {
     console.log('삭제하기')
-    // TODO: 삭제 기능 구현
   }
 }
 
 const colors = ['#FFD60A', '#FF6B9D', '#98D8C8', '#B4E4FF', '#E88555']
 const getBadgeColor = (idx: number) => colors[idx % colors.length]
 
-// 👇 ESC 키 이벤트 핸들러
 const handleKeydown = (e: KeyboardEvent) => {
   if (e.key === 'Escape') {
     if (isTripDetailModalVisible.value) {
@@ -464,10 +504,9 @@ const handleKeydown = (e: KeyboardEvent) => {
   }
 }
 
-// 드롭다운 외부 클릭 시 닫기
 const handleClickOutside = (e: MouseEvent) => {
   const target = e.target as HTMLElement
-  if (!target.closest('.relative')) {
+  if (showDropdown.value && !target.closest('.relative')) {
     showDropdown.value = false
   }
 }
@@ -483,7 +522,6 @@ onUnmounted(() => {
 })
 
 const formatCommentDate = (dateString: string) => {
-  // 간단한 시간 차이 계산 (실제 프로덕션에서는 date-fns/formatDistanceToNow 등을 사용)
   const date = parseISO(dateString)
   const now = new Date()
   const diffSeconds = Math.round((now.getTime() - date.getTime()) / 1000)

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -143,12 +143,16 @@ export interface TripLogImage {
   orderIndex: number
 }
 
-export interface TripLogComment {
+export interface TripLogCommentResponse {
   commentId: number
   authorNickname: string
   authorImageUrl: string
   content: string
   createdAt: string
+}
+
+export interface TripLogCommentRequest {
+  content: string
 }
 
 export interface TripLogDetail {
@@ -164,6 +168,5 @@ export interface TripLogDetail {
   tripId: number
   tripTitle: string
   images: TripLogImage[]
-  comments: TripLogComment[]
+  comments: TripLogCommentResponse[]
 }
-


### PR DESCRIPTION
<img width="500" height="" alt="image" src="https://github.com/user-attachments/assets/b7753185-c658-4d11-8cd8-bdbb821a8610" />

<img width="500" height="" alt="image" src="https://github.com/user-attachments/assets/66b02d9d-9ee6-4d8b-ac25-3307709f7c69" />

## Issue
- close #26 
- close #27 

## Details

 ### ✨ 주요 변경 내용
   1. 다이어리 댓글 기능 구현
       - 여행 기록(다이어리) 상세 모달에서 사용자가 댓글을 작성하고 제출할 수 있는 기능을 추가했습니다.
       - 댓글 목록을 실시간으로 갱신하여 즉각적인 피드백을 제공합니다.

   2. 인증 상태에 따른 UI/UX 개선
       - 댓글창 개인화: 로그인한 사용자의 경우, 댓글 입력창 옆에 본인의 프로필 사진이 표시됩니다.
       - 로그인 유도 강화:
           - 비로그인 사용자는 댓글 입력창이 비활성화되며, "로그인 후 댓글을 남길 수 있습니다."라는 안내 문구가 나타납니다.
           - 이 비활성화된 입력창을 클릭하면 로그인 페이지로 이동을 유도하는 모달이 표시됩니다.


  ### 🐛 버그 수정 및 안정성 강화
   1. 카카오맵 로딩 레이스 컨디션(Race Condition) 해결
       - 간헐적으로 kakao.maps.Size is not a constructor 오류가 발생하며 지도가 로딩되지 않던 문제를 해결했습니다.
       - 지도 SDK가 완전히 로드될 때까지 폴링(polling)으로 대기하고, 지도 로딩 완료 여부를 확인하는 가드 로직을 추가하여 안정성을 대폭 향상시켰습니다.

   2. 컴포넌트 렌더링 오류 수정
       - v-if와 v-for의 상호작용으로 인해 dayNumber를 찾지 못해 렌더링이 실패하던 문제를 해결했습니다.
       - <Transition> 컴포넌트의 자식 요소 규칙 위반으로 인해 발생하던 빌드 오류를 수정했습니다.
       - emit 함수의 초기화 오류(Cannot access 'emit' before initialization)를 수정했습니다.

### 💬 기타
   - 로그인 알림 등 범용적으로 사용할 수 있는 AlertDialog.vue 컴포넌트를 추가했습니다.
   - API 및 타입 정의(TripLogCommentRequest 등)를 추가/수정했습니다.