### PR TITLE
feat : 메인 화면 카드 컴포넌트 전체 목록 조회 api 연동

### DIFF
--- a/src/apis/http.ts
+++ b/src/apis/http.ts
@@ -22,8 +22,7 @@ apiClient.interceptors.request.use(async (config) => {
 
   if (
     config.url?.startsWith('/auth/refresh') ||
-    config.url?.startsWith('/auth/login') ||
-    config.url?.startsWith('/auth/logout')
+    config.url?.startsWith('/auth/login')
   ) {
     delete config.headers?.Authorization
     return config;

--- a/src/apis/trip-log/index.ts
+++ b/src/apis/trip-log/index.ts
@@ -1,0 +1,96 @@
+import apiClient from '@/apis/http'
+import type {
+    TripLogCommentRequest,
+    TripLogCommentResponse,
+    TripLogLikeResponse,
+    TripLogFeedResponseDto 
+} from '@/apis/trip-log/types'
+  
+import type { TripLogDetail } from '@/types/trip/trip.model'
+
+/**
+ * 여행 기록(로그) 상세 정보를 조회합니다.
+ * @param logId 조회할 여행 기록의 ID
+ * @returns 여행 기록 상세 정보 (TripLogDetail)
+ */
+export const getTripLogDetail = async (logId: number): Promise<TripLogDetail> => {
+  const response = await apiClient.get<TripLogDetail>(`/trip-logs/${logId}`)
+  return response.data
+}
+
+/**
+ * 여행 기록(로그)에 댓글을 작성합니다.
+ * @param logId 댓글을 작성할 여행 기록의 ID
+ * @param commentData 댓글 내용
+ * @returns 생성된 댓글 정보
+ */
+export const postTripLogComment = async (
+  logId: number,
+  commentData: TripLogCommentRequest,
+): Promise<TripLogCommentResponse> => {
+  const response = await apiClient.post<TripLogCommentResponse>(
+    `/trip-logs/${logId}/comments`,
+    commentData,
+  )
+  return response.data
+}
+
+/**
+ * 특정 여행 기록에 좋아요를 추가합니다.
+ * @param logId 좋아요를 누를 여행 기록의 ID
+ * @returns 업데이트된 좋아요 수 및 좋아요 상태 (TripLogLikeResponse)
+ */
+export const likeTripLog = async (logId: number): Promise<TripLogLikeResponse> => {
+  const response = await apiClient.post<TripLogLikeResponse>(`/trip-logs/${logId}/likes`)
+  return response.data
+}
+
+/**
+ * 특정 여행 기록의 좋아요를 취소합니다.
+ * @param logId 좋아요를 취소할 여행 기록의 ID
+ * @returns 업데이트된 좋아요 수 및 좋아요 상태 (TripLogLikeResponse)
+ */
+export const unlikeTripLog = async (logId: number): Promise<TripLogLikeResponse> => {
+  const response = await apiClient.delete<TripLogLikeResponse>(`/trip-logs/${logId}/likes`)
+  return response.data
+}
+
+/**
+ * 현재 사용자가 특정 여행 기록에 좋아요를 눌렀는지 여부와 총 좋아요 수를 조회합니다.
+ * @param logId 좋아요 상태를 조회할 여행 기록의 ID
+ * @returns 좋아요 상태 정보 (TripLogLikeResponse)
+ */
+export const getTripLogLikeStatus = async (logId: number): Promise<TripLogLikeResponse> => {
+  const response = await apiClient.get<TripLogLikeResponse>(`/trip-logs/${logId}/likes/status`)
+  return response.data
+}
+
+
+interface GetTripLogFeedParams {
+  cursor?: number | null; // optional, 첫 요청 시 null
+  limit?: number;
+}
+
+/**
+ * 여행 로그 피드를 조회하는 API 함수 (무한 스크롤)
+ * @param params.cursor 다음 페이지를 위한 커서 값
+ * @param params.limit 페이지 당 항목 수 (기본 10)
+ * @returns {Promise<GetTripLogFeedResponseDto>}
+ */
+export async function getTripLogFeed(
+  params: GetTripLogFeedParams,
+): Promise<TripLogFeedResponseDto> {
+  // cursor가 null이면 쿼리 파라미터에서 제외 (첫 페이지 요청)
+  const cursorParam = params.cursor !== null && params.cursor !== undefined
+    ? { cursor: params.cursor }
+    : {};
+  
+  const response = await apiClient.get<TripLogFeedResponseDto>('/trip-logs/feed', {
+    params: {
+      ...cursorParam,
+      limit: params.limit ?? 10,
+    },
+  });
+
+  return response.data;
+}

--- a/src/apis/trip-log/types.ts
+++ b/src/apis/trip-log/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Feed 관련 타입
+ */
+
+// 이미지 정보 DTO
+export interface TripLogImageDto {
+  imageRefKey: string;
+  imageUrl: string;
+  orderIndex: number;
+}
+
+// 피드 항목 DTO
+export interface TripLogFeedItemDto {
+  logId: number;
+  authorId: number;
+  authorNickname: string;
+  authorImageUrl: string;
+  title: string;
+  content: string;
+  locationSummary: string;
+  likeCount: number;
+  commentCount: number;
+  liked: boolean;
+  images: TripLogImageDto[];
+  createdAt: string; // ISO 8601 string
+}
+
+// 피드 조회 응답 DTO (Cursor 기반 Pagination)
+export interface TripLogFeedResponseDto {
+  content: TripLogFeedItemDto[];
+  nextCursor: number | null; // 다음 페이지를 요청할 때 사용할 커서 값
+  hasNext: boolean; // 다음 페이지가 있는지 여부
+}
+  
+/**
+ * TripLog 관련 타입 
+ */
+
+export interface TripLogLikeResponse {
+  likeCount: number;
+  liked: boolean;
+}
+
+export interface TripLogCommentResponse {
+  commentId: number
+  authorNickname: string
+  authorImageUrl: string
+  content: string
+  createdAt: string
+}
+
+export interface TripLogCommentRequest {
+  content: string
+}

--- a/src/apis/trip/index.ts
+++ b/src/apis/trip/index.ts
@@ -1,18 +1,13 @@
 import apiClient from '@/apis/http'
 import type {
-    TripDetailResponseDto,
-    TripItemResponseDto,
-    TripItemsUpdateRequestDto, 
-    TripUpdateRequestDto,
-    TripResponseDto,
-    TripSummaryResponseDto, 
-    TripLogCommentRequest,
-    TripLogCommentResponse,
-    TripLogLikeResponse,
-  } from '@/apis/trip/types'
+  TripDetailResponseDto,
+  TripItemResponseDto,
+  TripItemsUpdateRequestDto, 
+  TripUpdateRequestDto,
+  TripResponseDto,
+  TripSummaryResponseDto
+} from '@/apis/trip/types'
   
-
-import type {TripLogDetail } from '@/types/trip/trip.model'
 import { TripStatus } from '@/types/common'; 
 
 // API 호출 함수
@@ -93,59 +88,3 @@ export const getMyTripSummaries = async (): Promise<TripSummaryResponseDto[]> =>
   return response.data
 }
 
-/**
- * 여행 기록(로그) 상세 정보를 조회합니다.
- * @param logId 조회할 여행 기록의 ID
- * @returns 여행 기록 상세 정보 (TripLogDetail)
- */
-export const getTripLogDetail = async (logId: number): Promise<TripLogDetail> => {
-  const response = await apiClient.get<TripLogDetail>(`/trip-logs/${logId}`)
-  return response.data
-}
-
-/**
- * 여행 기록(로그)에 댓글을 작성합니다.
- * @param logId 댓글을 작성할 여행 기록의 ID
- * @param commentData 댓글 내용
- * @returns 생성된 댓글 정보
- */
-export const postTripLogComment = async (
-  logId: number,
-  commentData: TripLogCommentRequest,
-): Promise<TripLogCommentResponse> => {
-  const response = await apiClient.post<TripLogCommentResponse>(
-    `/trip-logs/${logId}/comments`,
-    commentData,
-  )
-  return response.data
-}
-
-/**
- * 특정 여행 기록에 좋아요를 추가합니다.
- * @param logId 좋아요를 누를 여행 기록의 ID
- * @returns 업데이트된 좋아요 수 및 좋아요 상태 (TripLogLikeResponse)
- */
-export const likeTripLog = async (logId: number): Promise<TripLogLikeResponse> => {
-  const response = await apiClient.post<TripLogLikeResponse>(`/trip-logs/${logId}/likes`)
-  return response.data
-}
-
-/**
- * 특정 여행 기록의 좋아요를 취소합니다.
- * @param logId 좋아요를 취소할 여행 기록의 ID
- * @returns 업데이트된 좋아요 수 및 좋아요 상태 (TripLogLikeResponse)
- */
-export const unlikeTripLog = async (logId: number): Promise<TripLogLikeResponse> => {
-  const response = await apiClient.delete<TripLogLikeResponse>(`/trip-logs/${logId}/likes`)
-  return response.data
-}
-
-/**
- * 현재 사용자가 특정 여행 기록에 좋아요를 눌렀는지 여부와 총 좋아요 수를 조회합니다.
- * @param logId 좋아요 상태를 조회할 여행 기록의 ID
- * @returns 좋아요 상태 정보 (TripLogLikeResponse)
- */
-export const getTripLogLikeStatus = async (logId: number): Promise<TripLogLikeResponse> => {
-  const response = await apiClient.get<TripLogLikeResponse>(`/trip-logs/${logId}/likes/status`)
-  return response.data
-}

--- a/src/apis/trip/types.ts
+++ b/src/apis/trip/types.ts
@@ -117,28 +117,6 @@ export interface TripPlanResponseDto {
   endDate: string; // 카드 날짜
   visibility: 'PUBLIC' | 'PRIVATE' | 'PROTECTED'; // 필터링에 사용됨
 }
-
-
-/**
- * TripLog 관련 타입 
- */
-
-export interface TripLogLikeResponse {
-    likeCount: number;
-    liked: boolean;
-}
-
-export interface TripLogCommentResponse {
-    commentId: number
-    authorNickname: string
-    authorImageUrl: string
-    content: string
-    createdAt: string
-}
-
-export interface TripLogCommentRequest {
-    content: string
-}
   
 
 /**
@@ -157,3 +135,4 @@ export interface TripDiaryResponseDto {
   likes: number;
   comments: number;
 }
+

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -6,7 +6,7 @@ import type { User } from '@/types/auth/user.model';
  */
 export const fetchUserProfile = async (userId: number): Promise<User | null> => {
     try {
-      const response = await apiClient.get<User>(`/user/${userId}/profile`);
+      const response = await apiClient.get<User>(`/users/${userId}/profile`);
       return response.data;
     } catch (error) {
       console.error(`Failed to fetch profile for user ${userId}:`, error);
@@ -19,7 +19,7 @@ export const fetchUserProfile = async (userId: number): Promise<User | null> => 
  */
 export const fetchFriends = async (userId: number): Promise<User[]> => {
     try {
-        const response = await apiClient.get<User[]>(`/user/${userId}/friends`);
+        const response = await apiClient.get<User[]>(`/users/${userId}/friends`);
         return response.data;
     } catch (error) {
         console.error(`Failed to fetch friends list for user ${userId}:`, error);

--- a/src/components/home/DiaryFeedItem.vue
+++ b/src/components/home/DiaryFeedItem.vue
@@ -28,16 +28,16 @@
           <div
             class="w-10 h-10 border-[2px] border-[#2C2C2C] rounded-lg overflow-hidden flex-shrink-0"
           >
-            <img :src="authorAvatar" :alt="author" class="w-full h-full object-cover" />
+            <img :src="props.authorImageUrl" :alt="props.authorNickname" class="w-full h-full object-cover" />
           </div>
           <div class="flex-1 min-w-0">
-            <h4 class="font-black font-sans">{{ author }}</h4>
+            <h4 class="font-black font-sans">{{ props.authorNickname }}</h4>
             <div class="flex items-center gap-2 text-xs font-bold text-gray-600">
               <MapPin class="w-3 h-3 flex-shrink-0" stroke-width="2" />
-              <span class="truncate">{{ location }}</span>
+              <span class="truncate">{{ props.locationSummary }}</span>
               <span>•</span>
               <Calendar class="w-3 h-3 flex-shrink-0" stroke-width="2" />
-              <span>{{ date }}</span>
+              <span>{{ props.createdAt }}</span>
             </div>
           </div>
         </div>
@@ -68,7 +68,7 @@
 
       <h3 class="text-lg font-black mb-2.5 tracking-tight leading-tight font-sans">{{ title }}</h3>
 
-      <div v-if="course && course.length > 0" class="mb-4 flex items-center flex-wrap gap-1.5">
+      <!-- <div v-if="course && course.length > 0" class="mb-4 flex items-center flex-wrap gap-1.5">
         <div v-for="(place, index) in course" :key="index" class="flex items-center gap-1.5">
           <button
             class="course-badge flex items-center gap-1 px-2.5 py-1 border-[2px] border-[#2C2C2C] rounded-full bg-white shadow-[1px_1px_0px_0px_rgba(44,44,44,0.1)] cursor-pointer hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.15)] hover:translate-x-[-1px] hover:translate-y-[-1px] transition-all focus:outline-none"
@@ -86,7 +86,7 @@
             stroke-width="3"
           />
         </div>
-      </div>
+      </div> -->
 
       <div
         v-if="allImages.length > 0"
@@ -149,8 +149,8 @@
           class="text-sm leading-relaxed font-medium text-gray-800 whitespace-pre-line cursor-pointer hover:opacity-80 transition-opacity"
           :class="{ 'line-clamp-3': !isExpanded }"
           @click="isExpanded = !isExpanded"
+          v-html="processedContent"
         >
-          {{ content }}
         </p>
       </div>
 
@@ -173,7 +173,7 @@
           class="flex items-center gap-1.5 px-3.5 py-2 border-[2px] border-[#2C2C2C] rounded-full font-black text-xs transition-all uppercase bg-white hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)] hover:translate-x-[-1px] hover:translate-y-[-1px] focus:outline-none"
         >
           <MessageCircle class="w-3.5 h-3.5" stroke-width="2.5" />
-          <span>{{ comments }}</span>
+          <span>{{ props.commentCount }}</span>
         </button>
 
         <button
@@ -186,7 +186,7 @@
     <Teleport to="body">
       <DiaryCommentModal
         v-if="showCommentModal"
-        :log-id="id"
+        :log-id="props.logId"
         @close="showCommentModal = false"
       />
 
@@ -209,31 +209,18 @@ import {
 } from 'lucide-vue-next'
 import DiaryCommentModal from '@/components/modal/DiaryCommentModal.vue'
 import PlaceDetailModal from '@/components/modal/PlaceDetailModal.vue'
+import type { TripLogFeedItemDto } from '@/apis/trip-log/types';
 
 interface CourseItem {
   number: number
   name: string
 }
 
-const props = defineProps<{
-  id: number
-  author: string
-  authorAvatar: string
-  location: string
-  date: string
-  title: string
-  content: string
-  imageUrl?: string
-  images?: string[]
-  likes: number
-  comments: number
-  course?: CourseItem[]
-}>()
-
+const props = defineProps<TripLogFeedItemDto>();
 // State
-const isLiked = ref(false)
+const isLiked = ref(props.liked)
 const isBookmarked = ref(false)
-const currentLikes = ref(props.likes)
+const currentLikes = ref(props.likeCount)
 const isExpanded = ref(false)
 const currentImageIndex = ref(0)
 const showToast = ref(false)
@@ -243,7 +230,13 @@ const showCommentModal = ref(false)
 const selectedPlace = ref<CourseItem | null>(null)
 
 // Images Logic
-const allImages = computed(() => props.images || (props.imageUrl ? [props.imageUrl] : []))
+const allImages = computed(() => {
+  // props.images가 존재하면, .map을 사용하여 imageUrl 속성만 추출
+  if (props.images && props.images.length > 0) {
+    return props.images.map(img => img.imageUrl);
+  }
+  return [];
+});
 const prevImage = () => {
   currentImageIndex.value = Math.max(0, currentImageIndex.value - 2)
 }
@@ -260,7 +253,7 @@ const toggleLike = () => {
 
 // Share Action
 const handleShare = async () => {
-  const diaryUrl = `${window.location.origin}/diary/${props.id}`
+  const diaryUrl = `${window.location.origin}/diary/${props.logId}`
 
   try {
     await navigator.clipboard.writeText(diaryUrl)
@@ -277,6 +270,49 @@ const handleShare = async () => {
 // Course Badge Colors
 const colors = ['#FFD60A', '#FF6B9D', '#98D8C8', '#B4E4FF', '#E88555']
 const getBadgeColor = (idx: number) => colors[idx % colors.length]
+
+const imageMap = computed(() => {
+  const map = new Map<string, string>();
+  if (props.images) {
+    props.images.forEach(img => {
+      map.set(img.imageRefKey, img.imageUrl);
+    });
+  }
+  return map;
+});
+
+// 2. 본문 내용 처리: 플레이스홀더를 <img> 태그로 대체
+const processedContent = computed(() => {
+  let text = props.content || '';
+  const map = imageMap.value;
+
+  // 정규식을 사용하여 {{img_key_숫자}} 패턴을 찾고 대체합니다.
+  text = text.replace(/\{\{img_key_(\d+)\}\}/g, (match, keyIndex) => {
+    const refKey = `img_key_${keyIndex}`;
+    
+    // 맵에서 해당 키에 맞는 URL을 찾습니다.
+    const imageUrl = map.get(refKey);
+
+    if (imageUrl) {
+      // 찾았다면 <img> 태그로 대체 (Tailwind CSS 스타일링 적용)
+      return `
+        <div class="my-3 flex justify-center">
+          <img 
+            src="${imageUrl}" 
+            alt="첨부 이미지" 
+            class="w-full max-w-[400px] h-auto rounded-lg border-[2px] border-[#2C2C2C] object-cover" 
+          />
+        </div>
+      `;
+    }
+    // 이미지를 찾지 못했거나 키가 잘못된 경우, 빈 문자열로 대체 (제거)
+    return ''; 
+  });
+  
+  return text;
+});
+
+
 </script>
 
 <style scoped>

--- a/src/components/modal/DiaryCommentModal.vue
+++ b/src/components/modal/DiaryCommentModal.vue
@@ -350,7 +350,8 @@ import {
   Edit,
   Trash2,
 } from 'lucide-vue-next'
-import { getTripLogDetail, getTripDetail, postTripLogComment, likeTripLog, unlikeTripLog, getTripLogLikeStatus } from '@/apis/trip'
+import { getTripDetail } from '@/apis/trip/index'
+import { getTripLogDetail, postTripLogComment, likeTripLog, unlikeTripLog, getTripLogLikeStatus } from '@/apis/trip-log/index'
 import type { TripDetailResponseDto } from '@/apis/trip/types'
 import type { TripLogDetail } from '@/types/trip/trip.model'
 import { format, parseISO } from 'date-fns'

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -6,7 +6,7 @@
       <div class="flex gap-8 items-start justify-center">
         <div class="flex-1 max-w-[680px]">
           <div class="space-y-5">
-            <template v-for="diary in diaryEntries" :key="diary.id">
+            <template v-for="diary in diaryEntries" :key="diary.logId">
               <DiaryFeedItem v-bind="diary" />
             </template>
           </div>
@@ -16,6 +16,7 @@
               v-if="isLoading"
               class="inline-block w-10 h-10 border-[3px] border-[#2C2C2C] border-t-transparent rounded-full animate-spin"
             ></div>
+            <p v-else-if="!hasNext" class="text-gray-500">모든 피드를 불러왔습니다.</p>
           </div>
         </div>
 
@@ -40,15 +41,20 @@ import TravelNavbar from '@/components/common/TravelNavbar.vue'
 import ScrollToTop from '@/components/common/ScrollToTop.vue'
 import DiaryFeedItem from '@/components/home/DiaryFeedItem.vue'
 import FollowingPanel from '@/components/home/FollowingPanel.vue'
-import { initialDiaries, initialFollowers } from '@/data/dummy'
+import { initialFollowers } from '@/data/dummy'
+import type { TripLogFeedItemDto } from '@/apis/trip-log/types';
+import { getTripLogFeed } from '@/apis/trip-log/index';
 
 const { handleNavigate } = useNavigate()
 
 // 상태 관리
-const diaryEntries = ref([...initialDiaries])
+const diaryEntries = ref<TripLogFeedItemDto[]>([])
 const followers = ref([...initialFollowers])
 const isLoading = ref(false)
 const observerTarget = ref<HTMLElement | null>(null)
+const nextCursor = ref<number | null>(null) // null이면 첫 페이지를 의미
+const hasNext = ref(true) // 다음 페이지 존재 여부
+
 
 // 팔로우 토글 로직
 const toggleFollow = (id: number) => {
@@ -58,28 +64,40 @@ const toggleFollow = (id: number) => {
   }
 }
 
-// 무한 스크롤 로직
-let observer: IntersectionObserver | null = null
+// 무한 스크롤 로직 : API 호출
+const loadMore = async () => {
+  // 이미 로딩 중이거나 다음 페이지가 없으면 리턴
+  if (isLoading.value || !hasNext.value) return
 
-const loadMore = () => {
-  if (isLoading.value) return
   isLoading.value = true
 
-  setTimeout(() => {
-    const newItems = initialDiaries.map((item, idx) => ({
-      ...item,
-      id: diaryEntries.value.length + idx + 1,
-    }))
+  try {
+    const response = await getTripLogFeed({
+      cursor: nextCursor.value,
+      limit: 10
+    })
 
-    diaryEntries.value.push(...newItems)
+    diaryEntries.value.push(...response.content)
+    nextCursor.value = response.nextCursor
+    hasNext.value = response.hasNext
+  } catch (error) {
+    console.error('피드 로딩 중 오류 발생: ', error)
+  } finally {
     isLoading.value = false
-  }, 1000)
+  }
 }
 
+// 무한 스크롤 Intersection Observer 로직 (유지)
+let observer: IntersectionObserver | null = null;
+
 onMounted(() => {
+  // 💡 첫 페이지 로드
+  loadMore()
+
   observer = new IntersectionObserver(
     (entries) => {
-      if (entries[0]?.isIntersecting) {
+      // 뷰포트에 타겟이 들어왔고, 다음 페이지가 존재할 때만 loadMore 호출
+      if (entries[0]?.isIntersecting && hasNext.value) { 
         loadMore()
       }
     },
@@ -94,4 +112,5 @@ onMounted(() => {
 onUnmounted(() => {
   if (observer) observer.disconnect()
 })
+
 </script>


### PR DESCRIPTION
## Issue
- close #32 

---
## Detail
### ✨ Features

#### 1. 메인 피드 목록 조회 (API 연동)
- `/api/trip-logs/feed` API를 연동하여 홈 화면에 여행 기록 피드 목록을 표시했습니다.
- 무한 스크롤 / 페이지네이션 구현을 위해 `nextCursor` 값을 이용하여 다음 페이지를 로드하는 로직을 적용했습니다.

#### 2. 피드 아이템 (`DiaryFeedItem.vue`) 수정
- API 응답 DTO (`TripLogFeedItemDto`)를 기반으로 피드 아이템의 모든 정보를 바인딩했습니다.

#### 3. 이미지 처리 로직
- **본문 내 이미지 삽입:** `content` 필드에 포함된 **플레이스홀더** (`{{img_key_1}}`)를 `images` 배열과 매핑하여 해당 위치에 실제 `<img>` 태그를 삽입하는 로직을 구현했습니다.
  - 플레이스홀더를 HTML `<img>` 태그로 치환하기 위해 `v-html`을 사용했습니다.

#### 4. 타입 및 모듈 정리
- `src/apis/trip-log/types.ts`에 `TripLogFeedItemDto` 및 관련 타입을 정의했습니다.

---

### 🐛 Fixes & Improvements
- `user`에서 `users`로 path 수정
- 기존에 `Authorized` 헤더 제거 대상 목록에서 `POST /auth/logout` 요청 제외