### PR TITLE
refactor: Trip API Spec 변경에 따른 프론트엔드 수정

### DIFF
--- a/src/apis/trip/index.ts
+++ b/src/apis/trip/index.ts
@@ -2,13 +2,13 @@ import apiClient from '@/apis/http'
 import type {
   TripDetailResponseDto,
   TripItemResponseDto,
-  TripItemsUpdateRequestDto, 
+  TripItemsReplaceRequestDto,
   TripUpdateRequestDto,
   TripResponseDto,
   TripSummaryResponseDto
 } from '@/apis/trip/types'
-  
-import { TripStatus } from '@/types/common'; 
+
+import { TripStatus } from '@/types/common';
 
 // API 호출 함수
 /**
@@ -47,7 +47,7 @@ export const deleteTrip = async (tripId: number): Promise<void> => {
  */
 export const syncTripItems = async (
   tripId: number,
-  syncData: TripItemsUpdateRequestDto, // Changed type
+  syncData: TripItemsReplaceRequestDto, // Changed type
 ): Promise<TripItemResponseDto[]> => {
   const response = await apiClient.put<TripItemResponseDto[]>(`/trips/${tripId}/items`, syncData)
   return response.data
@@ -63,7 +63,7 @@ export const updateTrip = async (
   tripId: number,
   updateData: TripUpdateRequestDto,
 ): Promise<TripDetailResponseDto> => {
-  const response = await apiClient.put<TripDetailResponseDto>(`/trips/${tripId}`, updateData)
+  const response = await apiClient.patch<TripDetailResponseDto>(`/trips/${tripId}`, updateData)
   return response.data
 }
 

--- a/src/apis/trip/types.ts
+++ b/src/apis/trip/types.ts
@@ -57,15 +57,14 @@ export interface TripResponseDto {
   startDate?: string // nullable
   endDate?: string // nullable
   status: TripStatus
-  visibility: TripVisibility
+  visibility?: TripVisibility
   isOwner: boolean
   spots: number // 추가됨
   tags?: string[] // 추가됨, nullable
   spotPreviews: { name: string }[] // 추가됨
   completedDate?: string // 추가됨, nullable
-  thumbnailUrl?: string
-  likes: number
-  comments: number
+  likes?: number
+  comments?: number
 }
 
 // 여행 요약 응답 DTO 인터페이스 (새로 추가됨)
@@ -81,27 +80,27 @@ export interface TripSummaryResponseDto {
 
 // 여행 정보 수정 요청 DTO
 export interface TripUpdateRequestDto {
-  title: string
+  title?: string
   startDate?: string // nullable
   endDate?: string // nullable
-  status: TripStatus
-  visibility: TripVisibility
+  status?: TripStatus
+  visibility?: TripVisibility
 }
 
-// 여행 아이템 목록 전체 수정 요청 DTO (TripItemSyncRequestDto -> TripItemsUpdateRequestDto)
-export interface TripItemsUpdateRequestDto {
-  days: TripItemsUpdateRequestDto_Day[]
+// 여행 아이템 목록 전체 교체 요청 DTO (TripItemsReplaceRequestDto)
+export interface TripItemsReplaceRequestDto {
+  days: TripItemsReplaceRequestDto_Day[]
 }
 
-export interface TripItemsUpdateRequestDto_Day {
+export interface TripItemsReplaceRequestDto_Day {
   dayNumber: number
-  items: TripItemsUpdateRequestDto_ItemSync[]
+  items: TripItemsReplaceRequestDto_Item[]
 }
 
-export interface TripItemsUpdateRequestDto_ItemSync {
-  tripItemId?: number // nullable
-  spot?: SpotRequestDto // nullable, 새로운 아이템인 경우 필수
-  memo?: string // nullable
+export interface TripItemsReplaceRequestDto_Item {
+  spotId?: number // 기존에 등록된 여행지 ID
+  spot?: SpotRequestDto // 새로운 여행지
+  // memo: string  <-- 제거됨 (OpenAPI Spec에 없음)
 }
 //==========================================================================
 

--- a/src/composables/trip/useTripPlan.ts
+++ b/src/composables/trip/useTripPlan.ts
@@ -1,8 +1,8 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import type {
-  TripItemsUpdateRequestDto, 
-  TripItemsUpdateRequestDto_ItemSync,
+  TripItemsReplaceRequestDto,
+  TripItemsReplaceRequestDto_Item,
   TripItemResponseDto,
   TripUpdateRequestDto,
 } from '@/apis/trip/types'
@@ -113,26 +113,23 @@ export function useTripPlan() {
     if (!tripTitle.value.trim()) return alert('제목을 입력해주세요.')
 
     try {
-      // 1. 여행 아이템 동기화
-      const itemPayload: TripItemsUpdateRequestDto = {
+      // 1. 여행 아이템 동기화 (전체 교체)
+      const itemPayload: TripItemsReplaceRequestDto = {
         days: days.value.map((day) => ({
           dayNumber: day.dayNumber,
-          items: day.places.map((place): TripItemsUpdateRequestDto_ItemSync => {
-            if (place.id !== undefined) {
-              return { tripItemId: place.id, memo: place.memo }
-            } else {
-              return {
-                spot: {
-                  kakaoPlaceId: place.kakaoPlaceId,
-                  name: place.name,
-                  address: place.address,
-                  category: place.category,
-                  lat: place.lat,
-                  lng: place.lng,
-                  placeUrl: place.placeUrl || '',
-                },
-                memo: place.memo,
-              }
+          items: day.places.map((place): TripItemsReplaceRequestDto_Item => {
+            // 모든 장소에 대해 spot 정보를 보냅니다. (DB에 있는 장소든 아니든)
+            // TripItem ID는 더 이상 보내지 않으며, backend가 전체를 교체합니다.
+            return {
+              spot: {
+                kakaoPlaceId: place.kakaoPlaceId,
+                name: place.name,
+                address: place.address,
+                category: place.category,
+                lat: place.lat,
+                lng: place.lng,
+                placeUrl: place.placeUrl || '',
+              },
             }
           }),
         })),


### PR DESCRIPTION
## Issue
- close #41 

## Details
Trip API OpenAPI Spec 변경 사항을 반영하여 API 호출 방식과 데이터 구조(DTO)를 수정했습니다.

### 🛠 변경 사항
1. API Spec 동기화 (src/apis/trip)
- updateTrip 메서드 변경: 기존 PUT 방식에서 PATCH 방식으로 변경되었습니다. (/trips/{tripId})
- DTO 구조 변경:
  - TripItemsUpdateRequestDto를 TripItemsReplaceRequestDto로 이름을 변경하고 구조를 업데이트했습니다.
  - memo 필드 삭제: Spec에서 제거됨에 따라 관련 코드에서 삭제했습니다.
  - Item 구조 변경: spotId (기존 장소) 또는 spot (새로운 장소) 중 하나를 선택적으로 보내는 구조(oneOf)를 반영했습니다.

2. 여행 저장 로직 수정 (src/composables/trip/useTripPlan.ts)
- saveTrip 시 호출되는 아이템 동기화 로직을 업데이트했습니다.
- 이제 개별 아이템의 tripItemId를 추적하지 않고, 전체 리스트를 spot 정보로 교체하는 방식으로 저장 요청을 보냅니다.