### PR TITLE
feat: 장소 썸네일 이미지 연결

### DIFF
--- a/src/apis/http.ts
+++ b/src/apis/http.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { useAuthStore } from '@/stores/auth';
 
 const apiClient = axios.create({
-  baseURL: 'http://localhost:8080/api', // Standard Spring Boot port
+  baseURL: 'https://tritt.o-r.kr/api', // Standard Spring Boot port
   headers: {
     'Content-Type': 'application/json',
   },
@@ -10,7 +10,7 @@ const apiClient = axios.create({
 });
 
 export const refreshClient = axios.create({
-  baseURL: 'http://localhost:8080/api',
+  baseURL: 'https://tritt.o-r.kr/api',
   withCredentials: true,
 })
 

--- a/src/apis/spot/index.ts
+++ b/src/apis/spot/index.ts
@@ -42,5 +42,10 @@ export const spotApi = {
     getSpotById: async (spotId: number): Promise<SpotResponseDto> => {
         const response = await http.get<SpotResponseDto>(`/spots/${spotId}`)
         return response.data
+    },
+
+    generateSpotThumbnail: async (spotId: number): Promise<SpotResponseDto> => {
+        const response = await http.post<SpotResponseDto>(`/spots/${spotId}/thumbnail`)
+        return response.data
     }
 }

--- a/src/components/modal/PlaceDetailModal.vue
+++ b/src/components/modal/PlaceDetailModal.vue
@@ -6,48 +6,73 @@
         @click.stop
       >
         <!-- Header Section -->
-        <div class="p-6 border-b-[3px] border-[#2C2C2C] bg-white relative">
-          <button
-            @click="emit('close')"
-            class="absolute top-6 right-6 p-2 border-[2px] border-[#2C2C2C] rounded-lg bg-white hover:bg-gray-50 transition-colors"
-          >
-            <X class="w-5 h-5 text-[#2C2C2C]" stroke-width="2" />
-          </button>
+        <!-- Header Section -->
+        <div class="relative w-full min-h-[250px] flex flex-col justify-end overflow-hidden" 
+             :class="localPlace.imageUrl ? 'bg-gray-900' : 'bg-white border-b-[3px] border-[#2C2C2C]'">
+             
+             <!-- Background Image -->
+             <div v-if="localPlace.imageUrl" class="absolute inset-0 z-0">
+                <img :src="localPlace.imageUrl" class="w-full h-full object-cover opacity-90" />
+                <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
+             </div>
 
-          <div class="pr-12">
-             <div class="flex flex-wrap gap-2 mb-3">
-              <span
-                v-for="(tag, index) in localPlace.tags"
-                :key="index"
-                class="px-2.5 py-1 border-[2px] border-[#2C2C2C] rounded-full bg-[#9BCCC4] text-xs font-black text-[#2C2C2C]"
+             <!-- Close Button -->
+             <button
+                @click="emit('close')"
+                class="absolute top-6 right-6 p-2 border-[2px] border-[#2C2C2C] rounded-lg bg-white hover:bg-gray-50 transition-colors z-20 shadow-sm"
               >
-                #{{ tag }}
-              </span>
-            </div>
-            <h2 class="text-3xl font-black tracking-tight font-sans text-[#2C2C2C] leading-tight mb-2">
-              {{ localPlace.name }}
-            </h2>
-          </div>
-          
-          <!-- Compact Info Bar -->
-           <div class="flex flex-wrap gap-x-6 gap-y-2 text-sm font-bold text-gray-600 mt-4">
-             <div class="flex items-center gap-1.5">
-               <MapPin class="w-4 h-4 text-[#2C2C2C]" stroke-width="2.5" />
-               <span class="truncate max-w-[200px]">{{ localPlace.address || '주소 정보 없음' }}</span>
+                <X class="w-5 h-5 text-[#2C2C2C]" stroke-width="2" />
+              </button>
+
+             <!-- Header Content -->
+             <div class="p-6 relative z-10 w-full pt-16">
+                  <div class="pr-12">
+                     <div class="flex flex-wrap gap-2 mb-3">
+                      <span
+                        v-for="(tag, index) in localPlace.tags"
+                        :key="index"
+                        :class="[
+                            'px-2.5 py-1 border-[2px] rounded-full text-xs font-black',
+                            localPlace.imageUrl 
+                                ? 'bg-white/90 border-transparent text-[#2C2C2C]' 
+                                : 'bg-[#9BCCC4] border-[#2C2C2C] text-[#2C2C2C]'
+                        ]"
+                      >
+                        #{{ tag }}
+                      </span>
+                    </div>
+                    
+                    <h2 
+                        class="text-4xl font-black tracking-tight font-sans leading-tight mb-3"
+                        :class="localPlace.imageUrl ? 'text-white drop-shadow-md' : 'text-[#2C2C2C]'"
+                    >
+                      {{ localPlace.name }}
+                    </h2>
+                  </div>
+                  
+                  <!-- Compact Info Bar -->
+                   <div 
+                        class="flex flex-wrap gap-x-6 gap-y-2 text-sm font-bold"
+                        :class="localPlace.imageUrl ? 'text-gray-200' : 'text-gray-600'"
+                    >
+                     <div class="flex items-center gap-1.5">
+                       <MapPin class="w-4 h-4" :class="localPlace.imageUrl ? 'text-white' : 'text-[#2C2C2C]'" stroke-width="2.5" />
+                       <span class="truncate max-w-[200px]">{{ localPlace.address || '주소 정보 없음' }}</span>
+                     </div>
+                     
+                     <div v-if="localPlace.phone" class="flex items-center gap-1.5">
+                       <Phone class="w-4 h-4" :class="localPlace.imageUrl ? 'text-white' : 'text-[#2C2C2C]'" stroke-width="2.5" />
+                       <span>{{ localPlace.phone }}</span>
+                     </div>
+                     
+                     <div v-if="localPlace.website" class="flex items-center gap-1.5">
+                       <Globe class="w-4 h-4" :class="localPlace.imageUrl ? 'text-white' : 'text-[#2C2C2C]'" stroke-width="2.5" />
+                       <a :href="localPlace.website" target="_blank" class="hover:text-[#E88555] hover:underline truncate max-w-[150px]">
+                         {{ truncateUrl(localPlace.website) }}
+                       </a>
+                     </div>
+                   </div>
              </div>
-             
-             <div v-if="localPlace.phone" class="flex items-center gap-1.5">
-               <Phone class="w-4 h-4 text-[#2C2C2C]" stroke-width="2.5" />
-               <span>{{ localPlace.phone }}</span>
-             </div>
-             
-             <div v-if="localPlace.website" class="flex items-center gap-1.5">
-               <Globe class="w-4 h-4 text-[#2C2C2C]" stroke-width="2.5" />
-               <a :href="localPlace.website" target="_blank" class="hover:text-[#E88555] hover:underline truncate max-w-[150px]">
-                 {{ truncateUrl(localPlace.website) }}
-               </a>
-             </div>
-           </div>
         </div>
 
         <div class="flex-1 overflow-y-auto bg-[#FAFAFA]">
@@ -331,6 +356,7 @@ const localPlace = computed(() => {
     address: props.place.location || props.place.address,
     phone: props.place.phone,
     website: props.place.website || props.place.placeUrl,
+    imageUrl: props.place.imageUrl
   }
 
   // API 응답이 있으면 덮어쓰기 (실제 DB 데이터 우선)
@@ -462,7 +488,7 @@ const fetchSpotData = async () => {
             lat: props.place.lat || 0,
             lng: props.place.lng || 0,
             placeUrl: props.place.placeUrl || '',
-            thumbnailUrl: ''
+            thumbnailUrl: props.place.imageUrl || ''
         }
         
         // POST /spots 호출 (200 OK or 201 Created)

--- a/src/components/modal/PlaceDetailModal.vue
+++ b/src/components/modal/PlaceDetailModal.vue
@@ -6,7 +6,6 @@
         @click.stop
       >
         <!-- Header Section -->
-        <!-- Header Section -->
         <div class="relative w-full min-h-[250px] flex flex-col justify-end overflow-hidden" 
              :class="localPlace.imageUrl ? 'bg-gray-900' : 'bg-white border-b-[3px] border-[#2C2C2C]'">
              

--- a/src/components/modal/PlaceDetailModal.vue
+++ b/src/components/modal/PlaceDetailModal.vue
@@ -355,7 +355,7 @@ const localPlace = computed(() => {
     address: props.place.location || props.place.address,
     phone: props.place.phone,
     website: props.place.website || props.place.placeUrl,
-    imageUrl: props.place.imageUrl
+    imageUrl: props.place.imageUrl || props.place.thumbnailUrl
   }
 
   // API 응답이 있으면 덮어쓰기 (실제 DB 데이터 우선)
@@ -487,7 +487,7 @@ const fetchSpotData = async () => {
             lat: props.place.lat || 0,
             lng: props.place.lng || 0,
             placeUrl: props.place.placeUrl || '',
-            thumbnailUrl: props.place.imageUrl || ''
+            thumbnailUrl: props.place.imageUrl || props.place.thumbnailUrl || ''
         }
         
         // POST /spots 호출 (200 OK or 201 Created)

--- a/src/components/modal/PlaceDetailModal.vue
+++ b/src/components/modal/PlaceDetailModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fixed inset-0 bg-black/60 z-[60]" @click="emit('close')">
+  <div class="fixed inset-0 bg-black/60 z-[60]" @click.stop="emit('close')">
     <div class="fixed inset-0 z-[60] flex items-center justify-center p-6 pointer-events-none">
       <div
         class="bg-white border-[3px] border-[#2C2C2C] rounded-2xl shadow-[8px_8px_0px_0px_rgba(44,44,44,1)] max-w-2xl w-full max-h-[85vh] flex flex-col pointer-events-auto overflow-hidden"

--- a/src/components/modal/TripDetailModal.vue
+++ b/src/components/modal/TripDetailModal.vue
@@ -48,7 +48,7 @@
 
       <div class="flex-1 flex overflow-hidden">
         <div
-          class="w-[320px] bg-white border-r-[3px] border-[#2C2C2C] flex flex-col overflow-hidden flex-shrink-0"
+          class="w-[400px] bg-white border-r-[3px] border-[#2C2C2C] flex flex-col overflow-hidden flex-shrink-0"
         >
           <div class="p-4 border-b-[2px] border-gray-200">
             <div class="flex items-center gap-2 overflow-x-auto no-scrollbar">
@@ -133,10 +133,22 @@
           </div>
 
           <!-- Place Detail Panel -->
-          <PlaceDetailPanel :place="selectedPlace" @close="selectedPlace = null" />
+          <PlaceDetailPanel 
+              :place="selectedPlace" 
+              @close="selectedPlace = null" 
+              @open-detail="handleOpenPlaceDetailModal"
+          />
         </div>
       </div>
     </div>
+    
+    <!-- Nested Place Detail Modal (z-index should be higher than this modal if not using teleport, but fixed inset-0 inside fixed inset-0 is tricky without teleport or high z-index) -->
+    <!-- Assuming PlaceDetailModal has high z-index (z-[60] vs this z-50) -->
+    <PlaceDetailModal 
+        v-if="showPlaceDetailModal && detailedPlace" 
+        :place="detailedPlace" 
+        @close="showPlaceDetailModal = false" 
+    />
   </div>
 </template>
 
@@ -145,6 +157,7 @@ import { ref, computed, onMounted, onUnmounted, watchEffect } from 'vue'
 import { Calendar, MapPin, Edit, ListChecks, Shield } from 'lucide-vue-next'
 import KakaoMap from '@/components/common/KakaoMap.vue'
 import PlaceDetailPanel from '@/components/trip/PlaceDetailPanel.vue'
+import PlaceDetailModal from '@/components/modal/PlaceDetailModal.vue'
 import type { TripDetailResponseDto, SpotResponseDto} from '@/apis/trip/types'
 
 interface DayPlanDisplay {
@@ -163,6 +176,8 @@ const kakaoMapRef = ref<any>(null)
 const activeDay = ref(1)
 const selectedPlace = ref<SpotResponseDto | null>(null)
 const selectedMarkerId = ref<number | string | null>(null)
+const showPlaceDetailModal = ref(false)
+const detailedPlace = ref<SpotResponseDto | null>(null)
 
 const days = computed<DayPlanDisplay[]>(() => {
   const grouped = props.trip.tripItems.reduce((acc, item) => {
@@ -258,6 +273,11 @@ const handleMarkerClick = (id: number | string) => {
   if (place) {
     handlePlaceClick(place)
   }
+}
+
+const handleOpenPlaceDetailModal = (place: SpotResponseDto) => {
+    detailedPlace.value = place
+    showPlaceDetailModal.value = true
 }
 
 const displayDuration = computed(() => {

--- a/src/components/modal/TripDetailModal.vue
+++ b/src/components/modal/TripDetailModal.vue
@@ -291,6 +291,7 @@ const displayDuration = computed(() => {
 
 const handleKeydown = (e: KeyboardEvent) => {
   if (e.key === 'Escape') {
+    if (showPlaceDetailModal.value) return
     emit('close')
   }
 }

--- a/src/components/trip/PlaceDetailPanel.vue
+++ b/src/components/trip/PlaceDetailPanel.vue
@@ -1,158 +1,107 @@
 <template>
   <div
     v-if="place"
-    class="h-64 bg-white border-t-[3px] border-[#2C2C2C] p-4 relative flex-shrink-0 overflow-y-auto"
+    class="h-40 bg-white border-t-[3px] border-[#2C2C2C] flex relative flex-shrink-0 overflow-hidden cursor-pointer hover:bg-gray-50 transition-colors"
+    @click="$emit('open-detail', place)"
   >
-    <button
-      @click="$emit('close')"
-      class="absolute top-3 right-3 p-2 bg-gray-200 rounded-full hover:bg-gray-300 transition-colors z-10"
-    >
-      <X :size="16" />
-    </button>
+    <!-- Left: Image Section -->
+    <div class="w-[160px] h-full flex-shrink-0 relative border-r border-gray-100 bg-gray-50">
+        <img v-if="place.thumbnailUrl" :src="place.thumbnailUrl" class="w-full h-full object-cover" />
+        <div v-else class="w-full h-full flex items-center justify-center">
+             <MapPin :size="24" class="text-gray-300" />
+        </div>
+    </div>
 
-    <div class="flex gap-4 h-full">
-      <!-- Left Column: Info -->
-      <div class="flex-1 flex flex-col">
-        <p class="text-xs font-bold text-gray-500 mb-1">{{ place.category }}</p>
-        <h3 class="text-2xl font-black mb-2 leading-tight">{{ place.name }}</h3>
+    <!-- Right: Content Section -->
+    <div class="flex-1 p-4 flex flex-col min-w-0 bg-transparent">
+       <!-- Close Button -->
+       <button
+          @click.stop="$emit('close')"
+          class="absolute top-3 right-3 p-1 text-gray-400 hover:text-[#2C2C2C] hover:bg-gray-200 rounded-full transition-colors z-10"
+        >
+          <X :size="16" />
+        </button>
 
-        <div class="flex flex-wrap gap-1 mb-3">
-          <span
-            v-for="(tag, index) in mockData.tags"
-            :key="index"
-            class="px-2 py-0.5 border-[1.5px] border-[#2C2C2C] rounded-full bg-[#B4E4FF] text-[10px] font-black"
-          >
-            #{{ tag }}
+       <!-- Category & Rating -->
+       <div class="flex items-center gap-2 mb-1">
+          <span class="text-[10px] font-bold text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded flex-shrink-0">
+             {{ place.category }}
           </span>
-        </div>
-
-        <div class="mt-auto space-y-2 text-xs">
-          <div class="flex items-center gap-2 font-bold">
-            <MapPin :size="14" class="flex-shrink-0" />
-            <span class="truncate">{{ place.address }}</span>
+          <div class="flex items-center gap-1 -ml-1 scale-90 origin-left">
+             <Star :size="12" class="fill-[#FFD60A] text-[#FFD60A]" />
+             <span class="text-xs font-black text-[#2C2C2C]">{{ reviewStats.averageRating.toFixed(1) }}</span>
+             <span class="text-[10px] text-gray-400 font-medium">({{ reviewStats.reviewCount }})</span>
           </div>
-          <div v-if="place.placeUrl" class="flex items-center gap-2 font-bold">
-            <Globe :size="14" class="flex-shrink-0" />
-            <a
-              :href="place.placeUrl"
-              target="_blank"
-              class="truncate text-blue-600 hover:underline"
-              @click.stop
-            >
-              {{ place.placeUrl }}
-            </a>
-          </div>
-        </div>
-      </div>
+       </div>
 
-      <!-- Right Column: Ratings & Reviews -->
-      <div class="w-48 flex flex-col border-l-2 border-gray-200 pl-4">
-        <!-- Average Rating -->
-        <div class="mb-3">
-          <p class="text-xs font-black text-gray-600 uppercase">평균 평점</p>
-          <div class="flex items-baseline gap-1">
-            <span class="font-black text-2xl">{{ mockData.rating }}</span>
-            <span class="text-xs font-bold text-gray-500">/ 5.0</span>
-          </div>
-        </div>
+       <!-- Title -->
+       <div class="mb-auto pr-6">
+          <h3 class="text-lg font-black text-[#2C2C2C] leading-tight group-hover:text-[#9BCCC4] transition-colors truncate">
+              {{ place.name }}
+          </h3>
+       </div>
 
-        <!-- My Rating -->
-        <div class="mb-4">
-          <p class="text-xs font-black text-gray-600 uppercase mb-1">내 평가</p>
-          <div class="flex items-center gap-1 cursor-pointer" @mouseleave="handleStarLeave">
-            <div
-              v-for="star in 5"
-              :key="star"
-              class="relative w-6 h-6"
-              @mousemove="(e) => handleStarHover(star - 1, e)"
-              @click="(e) => handleStarClick(star - 1, e)"
-            >
-              <Star class="absolute inset-0 w-6 h-6 fill-none text-gray-300" stroke-width="2" />
-              <div
-                class="absolute inset-0 overflow-hidden"
-                :style="{ width: `${getStarFillPercent(star - 1)}%` }"
-              >
-                <Star
-                  :class="[
-                    'absolute left-0 w-6 h-6',
-                    hoverRating > 0 || userRating === 0
-                      ? 'fill-[#FFD60A] text-[#FFD60A]'
-                      : 'fill-[#FF1493] text-[#FF1493]',
-                  ]"
-                  stroke-width="2"
-                />
-              </div>
-            </div>
-          </div>
-          <p v-if="userRating > 0" class="text-xs font-bold text-[#FF1493] mt-1">
-            내 평가: {{ userRating.toFixed(1) }}
-          </p>
-        </div>
+       <!-- Info -->
+       <div class="mt-2 space-y-1.5">
+           <div class="flex items-center gap-1.5 text-xs font-bold text-gray-600">
+             <MapPin :size="13" class="flex-shrink-0 text-gray-400" />
+             <span class="truncate">{{ place.address }}</span>
+           </div>
+           
+           <div v-if="place.phone" class="flex items-center gap-1.5 text-xs font-bold text-gray-600">
+             <Phone :size="13" class="flex-shrink-0 text-gray-400" />
+             <span class="truncate">{{ place.phone }}</span>
+           </div>
 
-        <!-- Reviews Placeholder -->
-        <div class="mt-auto">
-          <button
-            class="w-full flex items-center justify-center gap-2 py-2 bg-gray-100 text-gray-400 rounded-lg border-2 border-dashed border-gray-300"
-            disabled
-          >
-            <MessageSquare :size="14" />
-            <span class="text-xs font-bold">리뷰 (준비 중)</span>
-          </button>
-        </div>
-      </div>
+           <div v-if="place.placeUrl" class="flex items-center gap-1.5 group/link cursor-pointer" @click.stop>
+             <ArrowUpRight :size="13" class="flex-shrink-0 text-gray-400 group-hover/link:text-[#9BCCC4] transition-colors" />
+             <a :href="place.placeUrl" target="_blank" class="text-xs text-gray-400 group-hover/link:text-[#9BCCC4] underline decoration-gray-300 underline-offset-2 transition-colors">
+               상세보기
+             </a>
+           </div>
+       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { X, MapPin, Globe, Star, MessageSquare } from 'lucide-vue-next'
+import { ref, watch, computed } from 'vue'
+import { X, MapPin, Globe, Star, MessageSquare, ArrowUpRight, Phone } from 'lucide-vue-next'
 import type { SpotResponseDto } from '@/apis/trip/types'
+import { spotReviewApi } from '@/apis/spot-review'
 
 const props = defineProps<{
   place: SpotResponseDto | null
 }>()
 
-defineEmits(['close'])
+const emit = defineEmits(['close', 'open-detail'])
 
-// --- Mock Data ---
-const mockData = {
-  rating: 4.8,
-  tags: ['카페', '디저트', '감성'],
+const reviewStats = ref({ averageRating: 0, reviewCount: 0 })
+
+
+
+const fetchReviewStats = async () => {
+    if(!props.place?.id) return
+    try {
+        // Backend expects 'spotId' (number) but place might be from Kakao search (no ID yet if not saved)
+        // Check if place has an ID. If it's pure Kakao data in search phase, it might not have our DB ID.
+        // However, trip items usually have DB ID if saved. 
+        // If place.id is missing or looks like kakao ID, we might need check/create logic which exists in 'createSpot'.
+        // But for this panel appearing in search, it's safer to just show 0 if no ID.
+        if (props.place.id) {
+             const stats = await spotReviewApi.getSpotReviewStats(props.place.id)
+             reviewStats.value = stats
+        } else {
+             reviewStats.value = { averageRating: 0, reviewCount: 0 }
+        }
+    } catch (e) {
+        console.error("Failed to fetch stats", e)
+        reviewStats.value = { averageRating: 0, reviewCount: 0 }
+    }
 }
 
-// --- Star Rating Logic ---
-const userRating = ref<number>(0)
-const hoverRating = ref<number>(0)
+watch(() => props.place, () => {
+    fetchReviewStats()
+}, { immediate: true })
 
-const getAverageRatingRounded = () => {
-  return Math.floor(mockData.rating * 2) / 2
-}
-
-const handleStarHover = (starIndex: number, event: MouseEvent) => {
-  const target = event.currentTarget as HTMLElement
-  const rect = target.getBoundingClientRect()
-  const x = event.clientX - rect.left
-  hoverRating.value = x < rect.width / 2 ? starIndex + 0.5 : starIndex + 1
-}
-
-const handleStarClick = (starIndex: number, event: MouseEvent) => {
-  const target = event.currentTarget as HTMLElement
-  const rect = target.getBoundingClientRect()
-  const x = event.clientX - rect.left
-  const rating = x < rect.width / 2 ? starIndex + 0.5 : starIndex + 1
-  userRating.value = userRating.value === rating ? 0 : rating
-}
-
-const handleStarLeave = () => {
-  hoverRating.value = 0
-}
-
-const getStarFillPercent = (starIndex: number) => {
-  const displayRating = hoverRating.value || userRating.value || getAverageRatingRounded()
-  const starPosition = starIndex + 1
-  if (displayRating >= starPosition) return 100
-  if (displayRating > starIndex) return (displayRating - starIndex) * 100
-  return 0
-}
 </script>

--- a/src/composables/trip/usePlaceSearch.ts
+++ b/src/composables/trip/usePlaceSearch.ts
@@ -1,5 +1,6 @@
 import type { Place } from '@/types/trip/place.model'
 import { ref } from 'vue'
+import { spotApi } from '@/apis/spot'
 
 export function usePlaceSearch() {
   const searchQuery = ref('')
@@ -34,12 +35,13 @@ export function usePlaceSearch() {
         ps.keywordSearch(
           searchQuery.value,
           (data: any[], status: any) => {
-            // 1. 성공 시
             if (status === (window as any).kakao.maps.services.Status.OK) {
-              isSearching.value = false
               console.log('Kakao Search Results:', data)
+
+              // 1. Immediate UI Update
+              // 우선 카카오 데이터로 화면을 그린다 (ID는 카카오 ID 임시 사용)
               searchResults.value = data.map((item: any) => ({
-                id: Number(item.id),
+                id: Number(item.id), // 임시 ID (Kakao ID가 숫자가 아닐수도 있지만, Place Model이 number라 임시 변환)
                 kakaoPlaceId: item.id,
                 name: item.place_name,
                 address: item.road_address_name || item.address_name,
@@ -48,16 +50,65 @@ export function usePlaceSearch() {
                 lng: Number(item.x),
                 phone: item.phone,
                 placeUrl: item.place_url,
+                thumbnailUrl: undefined // 초기엔 없음
               }))
+
+              isSearching.value = false // 로딩 해제 (카드는 떴음)
+
+              // 2. Background Sync
+              // 각 아이템별로 독립적으로 백엔드 싱크 & 썸네일 생성 수행
+              data.forEach(async (item: any, index: number) => {
+                try {
+                  const spotRequest = {
+                    kakaoPlaceId: item.id,
+                    name: item.place_name,
+                    address: item.road_address_name || item.address_name,
+                    category: item.category_group_name || '기타',
+                    lat: Number(item.y),
+                    lng: Number(item.x),
+                    placeUrl: item.place_url,
+                    thumbnailUrl: ''
+                  }
+
+                  // A. Upsert Spot
+                  let spot = await spotApi.createSpot(spotRequest)
+
+                  // 업데이트: ID 교체 및 기존 썸네일 확인
+                  if (searchResults.value[index]) {
+                    searchResults.value[index] = {
+                      ...searchResults.value[index],
+                      id: spot.id, // 진짜 DB ID로 교체
+                      thumbnailUrl: spot.thumbnailUrl
+                    }
+                  }
+
+                  // B. 썸네일 없으면 생성 요청
+                  if (!spot.thumbnailUrl) {
+                    try {
+                      const updatedSpot = await spotApi.generateSpotThumbnail(spot.id)
+                      // 생성 완료 후 다시 업데이트
+                      if (searchResults.value[index]) {
+                        searchResults.value[index] = {
+                          ...searchResults.value[index],
+                          thumbnailUrl: updatedSpot.thumbnailUrl
+                        }
+                      }
+                    } catch (err) {
+                      console.warn(`Thumbnail generation failed for spot ${spot.id}`, err)
+                    }
+                  }
+
+                } catch (err) {
+                  console.error('Background sync failed for item', index, err)
+                }
+              })
             }
             // 2. 결과 없음 (ZERO_RESULT)
             else if (status === (window as any).kakao.maps.services.Status.ZERO_RESULT) {
-              // Fallback: 위치 제한이 있었고, 첫 시도였다면 -> 제한 없이 재검색
               if (options.bounds && !isFallbackAttempt) {
                 console.log('No results in current bounds. Retrying globally...')
-                executeSearch({}, true) // 재귀 호출 (옵션 제거)
+                executeSearch({}, true)
               } else {
-                // 진짜 결과 없음
                 isSearching.value = false
                 searchResults.value = []
               }

--- a/src/types/trip/place.model.ts
+++ b/src/types/trip/place.model.ts
@@ -12,7 +12,8 @@ export interface Place {
     phone?: string
     placeUrl?: string
     memo?: string // 아이템 메모
-    url?: string 
+    url?: string
+    thumbnailUrl?: string // 썸네일 이미지 URL
 }
 
 /**
@@ -22,6 +23,5 @@ export interface DayPlan {
     dayNumber: number
     places: Place[]
 }
-  
 
-  
+

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -378,8 +378,8 @@ const filteredPlaces = computed(() => {
   return searchResults.value.map(place => ({
     id: place.id,
     name: place.name,
-    // API에서 이미지가 오지 않으므로 null 설정 (UI에서 아이콘으로 대체)
-    imageUrl: null,
+    // API에서 이미지가 오면 사용, 없으면 null
+    imageUrl: place.thumbnailUrl || null,
     // 평점 정보 없음
     rating: 0.0,
     location: place.address,

--- a/src/views/TripPlanView.vue
+++ b/src/views/TripPlanView.vue
@@ -36,6 +36,7 @@
       />
 
       <div
+        v-if="trip.isEditMode.value"
         class="w-[6px] -ml-[3px] z-30 cursor-col-resize flex items-center justify-center hover:bg-[#9BCCC4] transition-colors opacity-0 hover:opacity-100 active:opacity-100 active:bg-[#9BCCC4]"
         @mousedown="startResize"
       >
@@ -111,7 +112,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { RotateCw } from 'lucide-vue-next'
 import KakaoMap from '@/components/common/KakaoMap.vue'
 import TripPlanHeader from '@/components/trip/TripPlanHeader.vue'
@@ -127,6 +128,14 @@ import { usePlaceSearch } from '@/composables/trip/usePlaceSearch'
 import { useTripPlan } from '@/composables/trip/useTripPlan'
 import { useMapInteraction } from '@/composables/trip/useMapInteraction'
 import TripAiChat from '@/components/trip/TripAiChat.vue' // [NEW]
+
+// 1. 패널 리사이징 로직
+const initialPanelWidth = 300
+const { width: panelWidth, startResize } = useResizablePanel({
+  initialWidth: initialPanelWidth,
+  minWidth: 200,
+  maxWidth: 300
+})
 
 // [NEW] AI 추천을 위한 주변 후보 장소 검색 (Frontend Kakao SDK 사용)
 // 다양한 카테고리 검색 (관광지, 문화시설, 음식점, 카페, 공원)
@@ -199,6 +208,12 @@ const {
 
 // 3. 여행 데이터 로직
 const trip = useTripPlan()
+
+watch(() => trip.isEditMode.value, (newVal) => {
+    if (!newVal) {
+        panelWidth.value = initialPanelWidth
+    }
+})
 
 // 4. [NEW] 지도 인터랙션 로직 (위의 상태들을 주입해서 연결)
 const mapInteraction = useMapInteraction({

--- a/src/views/TripPlanView.vue
+++ b/src/views/TripPlanView.vue
@@ -86,9 +86,17 @@
         <PlaceDetailPanel
           :place="selectedPlaceForDetail"
           @close="selectedPlaceForDetail = null"
+          @open-detail="handleOpenPlaceDetailModal"
         />
       </div>
     </div>
+    
+    <!-- Place Detail Modal -->
+    <PlaceDetailModal 
+        v-if="showPlaceDetailModal && detailedPlace" 
+        :place="detailedPlace" 
+        @close="showPlaceDetailModal = false" 
+    />
 
     <!-- AI Chatbot Floating Button -->
     <TripAiChat 
@@ -110,6 +118,7 @@ import TripPlanHeader from '@/components/trip/TripPlanHeader.vue'
 import TripPlanPanel from '@/components/trip/TripPlanPanel.vue'
 import TripSearchListPanel from '@/components/trip/TripSearchListPanel.vue'
 import PlaceDetailPanel from '@/components/trip/PlaceDetailPanel.vue'
+import PlaceDetailModal from '@/components/modal/PlaceDetailModal.vue'
 import type { Place } from '@/types/trip/place.model'
 
 // Import Composables
@@ -206,9 +215,9 @@ const mapInteraction = useMapInteraction({
 // 단, ref="kakaoMapRef" 연결을 위해 이것만 별도로 꺼내줍니다.
 const { kakaoMapRef } = mapInteraction
 
-
-
 const selectedPlaceForDetail = ref<Place | null>(null)
+const showPlaceDetailModal = ref(false)
+const detailedPlace = ref<Place | null>(null)
 
 // Helper to find a place from any list by its ID (trip item ID or kakaoPlaceId)
 const findPlaceById = (id: number | string): Place | undefined => {
@@ -242,6 +251,12 @@ const handleAddPlace = (place: Place) => {
     // 추가된 장소는 바로 패널을 띄우고 중심으로 이동
     showDetailAndPan(newPlace)
   }
+}
+
+// Handler for opening full detail modal from the side panel
+const handleOpenPlaceDetailModal = (place: Place) => {
+    detailedPlace.value = place
+    showPlaceDetailModal.value = true
 }
 
 // Ai Chat Search Handler


### PR DESCRIPTION

<img width="800" height="" alt="스크린샷 2025-12-22 오전 1 26 30" src="https://github.com/user-attachments/assets/211e6d70-e2dc-40ec-9030-6cea4ce318a1" />

<img width="800" height="" alt="스크린샷 2025-12-22 오전 1 26 40" src="https://github.com/user-attachments/assets/cba1bf4e-9781-46f2-9967-f04752433eca" />

<img width="800" height="" alt="스크린샷 2025-12-22 오전 1 26 52" src="https://github.com/user-attachments/assets/736833f1-06c1-4a04-83ee-bf447ef503f2" />

<img width="800" height="" alt="스크린샷 2025-12-22 오전 1 27 19" src="https://github.com/user-attachments/assets/6d9283de-4db4-4653-aac5-cdcd88d5cfa8" />

백엔드에 썸네일 이미지 api가 구현되었기 때문에
썸네일 이미지가 필요한 곳들을 연결했습니다.
여행 계획 페이지에 검색 패널 resizable이 사라졌던 것을 다시 적용했습니다.
