### PR TITLE
refactor: 새로운 계획 생성 뷰에서 헤더에 정상적으로 'PlANNED' 표시

### DIFF
--- a/src/components/trip/TripPlanHeader.vue
+++ b/src/components/trip/TripPlanHeader.vue
@@ -50,7 +50,7 @@
           <div class="flex items-center">
             <template v-if="isEditMode">
               <select
-                :value="tripStatus"
+                :value="tripStatus || 'PLANNED'"
                 @change="$emit('update:tripStatus', $event.target.value)"
                 class="px-3 py-2 border-[2px] border-[#2C2C2C] rounded-lg font-bold focus:outline-none focus:ring-2 focus:ring-[#9BCCC4] cursor-pointer bg-white"
               >
@@ -58,7 +58,7 @@
               </select>
             </template>
             <div v-else class="px-3 py-2 border-[2px] border-gray-300 rounded-lg bg-gray-50">
-              <span class="font-bold text-gray-700">{{ tripStatus }}</span>
+              <span class="font-bold text-gray-700">{{ tripStatus || 'PLANNED' }}</span>
             </div>
           </div>
 
@@ -66,7 +66,7 @@
           <div class="flex items-center">
             <template v-if="isEditMode">
               <select
-                :value="tripVisibility"
+                :value="tripVisibility || 'PUBLIC'"
                 @change="$emit('update:tripVisibility', $event.target.value)"
                 class="px-3 py-2 border-[2px] border-[#2C2C2C] rounded-lg font-bold focus:outline-none focus:ring-2 focus:ring-[#9BCCC4] cursor-pointer bg-white"
               >
@@ -75,7 +75,7 @@
               </select>
             </template>
             <div v-else class="px-3 py-2 border-[2px] border-gray-300 rounded-lg bg-gray-50">
-              <span class="font-bold text-gray-700">{{ tripVisibility }}</span>
+              <span class="font-bold text-gray-700">{{ tripVisibility || 'PUBLIC' }}</span>
             </div>
           </div>
         </div>
@@ -117,15 +117,21 @@ import { ArrowLeft, Save, Edit, Trash2, MapPin } from 'lucide-vue-next'
 import { TripStatus } from '@/types/common'
 import type { TripVisibility } from '@/types/trip/trip.model'
 
-defineProps<{
-  tripTitle: string
-  tripDate: string
-  formattedDate: string
-  isEditMode: boolean
-  totalPlacesCount: number
-  tripStatus: TripStatus | null
-  tripVisibility: TripVisibility | null
-}>()
+const props = withDefaults(
+  defineProps<{
+    tripTitle: string
+    tripDate: string
+    formattedDate: string
+    isEditMode: boolean
+    totalPlacesCount: number
+    tripStatus: TripStatus | null
+    tripVisibility: TripVisibility | null
+  }>(),
+  {
+    tripStatus: TripStatus.PLANNED,
+    tripVisibility: 'PUBLIC' as any,
+  },
+)
 
 defineEmits<{
   (e: 'back'): void

--- a/src/composables/trip/useTripPlan.ts
+++ b/src/composables/trip/useTripPlan.ts
@@ -38,8 +38,8 @@ export function useTripPlan() {
   const route = useRoute()
   const router = useRouter()
   const tripId = ref<number | null>(null)
-  const tripStatus = ref<TripStatus | null>(null)
-  const tripVisibility = ref<TripVisibility | null>(null)
+  const tripStatus = ref<TripStatus>(TripStatus.PLANNED)
+  const tripVisibility = ref<TripVisibility>('PUBLIC')
 
   // State
   const isEditMode = ref(false)
@@ -64,8 +64,17 @@ export function useTripPlan() {
       tripTitle.value = tripDetail.title
       tripLocationSummary.value = tripDetail.locationSummary || '' // Added
       tripDate.value = tripDetail.startDate || ''
-      tripStatus.value = tripDetail.status
-      tripVisibility.value = tripDetail.visibility
+      // DRAFT인 경우 PLANNED로 표시 (UI에서 DRAFT를 지원하지 않음)
+      tripStatus.value = (tripDetail.status === TripStatus.DRAFT || !tripDetail.status)
+        ? TripStatus.PLANNED
+        : tripDetail.status
+
+      // 가시성 데이터 보정: 신규 여행(날짜 미정)이거나 DRAFT인 경우 PUBLIC으로 유도
+      if (tripDetail.status === TripStatus.DRAFT || !tripDetail.startDate) {
+        tripVisibility.value = 'PUBLIC'
+      } else {
+        tripVisibility.value = tripDetail.visibility || 'PUBLIC'
+      }
 
       // API 응답을 로컬 상태로 변환
       const maxDay = tripDetail.tripItems.reduce((max, item) => Math.max(max, item.dayNumber), 0)


### PR DESCRIPTION
## refactor: 새로운 계획 생성 뷰에서 헤더에 정상적으로 'PlANNED' 표시

### 작업 내용
- 새로운 여행 계획 생성 시 DRAFT 상태로 들어오면 UI에서 PLANNED로 보이도록 보정 
- 가시성도 기본 PUBLIC으로 설정되도록 `useTripPlan.ts`를 수정또
- 또한 `TripPlanHeader.vue`에 이중 방어 로직을 넣어 이제 정상적으로 표시

<img width="1136" height="329" alt="image" src="https://github.com/user-attachments/assets/e084303b-b4cf-4283-9902-af9444d60d65" />
