### PR TITLE
feat: 알림 유형별 동작 분기 (친구 요청: 페이지 이동, 게시물: 모달)

### DIFF
--- a/src/components/common/TravelNavbar.vue
+++ b/src/components/common/TravelNavbar.vue
@@ -167,6 +167,12 @@
       </div>
     </div>
   </nav>
+
+  <DiaryCommentModal
+    v-if="showLogModal && selectedLogId"
+    :log-id="selectedLogId"
+    @close="handleLogClose"
+  />
 </template>
 
 <script setup lang="ts">
@@ -177,6 +183,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useNotificationStore } from '@/stores/notification'
 import { formatDistanceToNow } from 'date-fns'
 import { ko } from 'date-fns/locale'
+import DiaryCommentModal from '@/components/modal/DiaryCommentModal.vue'
 
 const authStore = useAuthStore()
 const notificationStore = useNotificationStore()
@@ -206,6 +213,10 @@ const showNotifications = ref(false)
 const userMenuRef = ref<HTMLDivElement | null>(null)
 const notificationRef = ref<HTMLDivElement | null>(null)
 
+// Modal State
+const showLogModal = ref(false)
+const selectedLogId = ref<number | null>(null)
+
 const handleClickOutside = (event: MouseEvent) => {
   if (userMenuRef.value && !userMenuRef.value.contains(event.target as Node)) {
     showUserMenu.value = false
@@ -233,10 +244,29 @@ const handleNotificationClick = async (notif: any) => {
   if (!notif.isRead) {
     await notificationStore.readNotification(notif.id)
   }
-  if (notif.targetUrl) {
-    router.push(notif.targetUrl)
+  
+  // 친구 관련 알림은 친구 페이지로 이동
+  if (notif.type === 'FRIEND_REQUEST' || notif.type === 'FRIEND_ACCEPT') {
+    if (notif.targetUrl) {
+      router.push(notif.targetUrl)
+    }
+  } 
+  // 로그 관련 알림(좋아요, 댓글, 스크랩)은 모달 띄우기
+  else if (['LIKE', 'COMMENT', 'SCRAP'].includes(notif.type)) {
+      selectedLogId.value = notif.targetId
+      showLogModal.value = true
   }
+  // 그 외(혹시 모를 경우)는 targetUrl로 이동 시도
+  else if (notif.targetUrl) {
+      router.push(notif.targetUrl)
+  }
+
   showNotifications.value = false
+}
+
+const handleLogClose = () => {
+    showLogModal.value = false
+    selectedLogId.value = null
 }
 
 const formatTime = (dateString: string) => {


### PR DESCRIPTION
## Issue
- #74 

---

## Description

알림 유형별 분기 로직을 수정했습니다.
<img width="375" height="193" alt="스크린샷 2025-12-23 오후 2 44 19" src="https://github.com/user-attachments/assets/d80e424c-bf6f-4158-aebf-48a511be52df" />

1. 좋아요/댓글/스크랩 등 게시물에 관한 알림 클릭 시 게시물이 모달창으로 나타납니다.
<img width="1346" height="1134" alt="스크린샷 2025-12-23 오후 2 44 58" src="https://github.com/user-attachments/assets/475bed5b-070c-4246-85df-35ab66f61aa2" />

2. 친구 요청에 관한 알림 클릭 시 친구 관리 페이지로 이동합니다.
<img width="1346" height="1134" alt="스크린샷 2025-12-23 오후 2 45 35" src="https://github.com/user-attachments/assets/5e5ff133-675a-4437-8f30-35c72817b3c0" />
