### PR TITLE
refactor: 메인페이지, trips 페이지 리팩토링 및 로그 디테일 페이지 구현

### DIFF
--- a/src/apis/trip-log/types.ts
+++ b/src/apis/trip-log/types.ts
@@ -47,6 +47,7 @@ export interface TripLogCommentResponse {
   commentId: number
   authorNickname: string
   authorImageUrl: string
+  authorId: number
   content: string
   createdAt: string
 }

--- a/src/components/home/DiaryFeedItem.vue
+++ b/src/components/home/DiaryFeedItem.vue
@@ -197,6 +197,7 @@
       <DiaryCommentModal
         v-if="showCommentModal"
         :log-id="props.logId"
+        :author-id="props.authorId"
         :initial-liked="isLiked"
         @close="showCommentModal = false"
         @update="handleModalUpdate"

--- a/src/components/home/DiaryFeedItem.vue
+++ b/src/components/home/DiaryFeedItem.vue
@@ -26,7 +26,7 @@
       class="bg-white rounded-xl border-[2px] border-[#2C2C2C] p-6 shadow-[4px_4px_0px_0px_rgba(44,44,44,1)] hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-[3px_3px_0px_0px_rgba(44,44,44,1)] transition-all"
     >
       <div class="flex items-center justify-between mb-5">
-        <div class="flex items-center gap-3 cursor-pointer hover:opacity-80 transition-opacity">
+        <div class="flex items-center gap-3 cursor-pointer hover:opacity-80 transition-opacity" @click="navigateToUserLog">
           <div
             class="w-10 h-10 rounded-full overflow-hidden flex-shrink-0 border-[2px] border-[#2C2C2C] bg-gray-100"
           >
@@ -209,6 +209,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import {
   Heart,
   MessageCircle,
@@ -229,6 +230,13 @@ interface CourseItem {
 }
 
 const props = defineProps<TripLogFeedItemDto>();
+const router = useRouter()
+
+const navigateToUserLog = () => {
+  if (props.authorId) {
+    router.push({ name: 'user-log', params: { userId: props.authorId } })
+  }
+}
 // State
 const isLiked = ref(props.liked)
 const isBookmarked = ref(false)

--- a/src/components/home/DiaryFeedItem.vue
+++ b/src/components/home/DiaryFeedItem.vue
@@ -93,7 +93,7 @@
       <div
         v-if="allImages.length > 0"
         class="mb-5 select-none cursor-pointer rounded-xl overflow-hidden border-[2px] border-[#2C2C2C] shadow-[3px_3px_0px_0px_rgba(0,0,0,0.1)]"
-        @click="showCommentModal = true"
+        @click="handleOpenLog"
       >
         <div v-if="allImages.length === 1" class="w-full">
           <img :src="allImages[0]" class="w-full h-auto max-h-[500px] object-cover" />
@@ -184,7 +184,7 @@
           </button>
 
           <button
-            @click="showCommentModal = true"
+            @click="handleOpenLog"
              class="flex items-center gap-1.5 px-3 py-1.5 border-[2px] border-[#2C2C2C] rounded-md font-black text-xs transition-all uppercase focus:outline-none bg-white text-[#2C2C2C] shadow-[2px_2px_0px_0px_rgba(44,44,44,1)] hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-none"
           >
             <MessageCircle class="w-3.5 h-3.5" stroke-width="2.5" />
@@ -194,15 +194,6 @@
       </div>
     </div>
     <Teleport to="body">
-      <DiaryCommentModal
-        v-if="showCommentModal"
-        :log-id="props.logId"
-        :author-id="props.authorId"
-        :initial-liked="isLiked"
-        @close="showCommentModal = false"
-        @update="handleModalUpdate"
-      />
-
       <PlaceDetailModal v-if="selectedPlace" :place="selectedPlace" @close="selectedPlace = null" />
     </Teleport>
   </div>
@@ -219,7 +210,6 @@ import {
   ChevronRight,
   ChevronLeft,
 } from 'lucide-vue-next'
-import DiaryCommentModal from '@/components/modal/DiaryCommentModal.vue'
 import PlaceDetailModal from '@/components/modal/PlaceDetailModal.vue'
 import type { TripLogFeedItemDto } from '@/apis/trip-log/types';
 import { likeTripLog, unlikeTripLog } from '@/apis/trip-log/index'
@@ -250,8 +240,15 @@ const isScrapping = ref(false)
 const toastMessage = ref('')
 
 // Modal States
-const showCommentModal = ref(false)
 const selectedPlace = ref<CourseItem | null>(null)
+
+const emit = defineEmits<{
+  (e: 'open-log', payload: { logId: number; authorId: number }): void
+}>()
+
+const handleOpenLog = () => {
+    emit('open-log', { logId: props.logId, authorId: props.authorId })
+}
 
 // Scrap Logic
 const handleScrap = async () => {

--- a/src/components/modal/DiaryCommentModal.vue
+++ b/src/components/modal/DiaryCommentModal.vue
@@ -38,6 +38,7 @@
     @close="emit('close')"
     @refresh="fetchLogDetail"
     @update="emit('update', $event)"
+    @edit="emit('edit', $event)"
   />
 </template>
 
@@ -55,7 +56,7 @@ const props = defineProps<{
   initialLiked?: boolean
 }>()
 
-const emit = defineEmits(['close', 'update'])
+const emit = defineEmits(['close', 'update', 'edit'])
 
 const logDetail = ref<TripLogDetail | null>(null)
 const tripDetail = ref<TripDetailResponseDto | null>(null)

--- a/src/components/modal/DiaryCommentModal.vue
+++ b/src/components/modal/DiaryCommentModal.vue
@@ -51,6 +51,7 @@ import TripDetailModal from './TripDetailModal.vue'
 
 const props = defineProps<{
   logId: number
+  authorId?: number // Optional since it might be missing in some contexts, but passed from feed
   initialLiked?: boolean
 }>()
 
@@ -71,7 +72,8 @@ const fetchLogDetail = async () => {
     const fetchedLogDetail = await getTripLogDetail(props.logId)
     logDetail.value = {
       ...fetchedLogDetail,
-      logId: props.logId
+      logId: props.logId,
+      authorId: props.authorId || fetchedLogDetail.authorId || 0
     }
 
     // 2. Trip 상세 조회 (Log에 연결된 Trip)

--- a/src/components/modal/TripDetailModal.vue
+++ b/src/components/modal/TripDetailModal.vue
@@ -62,10 +62,15 @@
           </div>
         </div>
 
-        <div class="relative" ref="headerDropdownContainer">
-          <button @click="showDropdown = !showDropdown" class="p-2 hover:bg-gray-100 rounded transition-all">
-            <MoreHorizontal class="w-6 h-6 text-[#2C2C2C]" stroke-width="2.5" />
+        <div class="flex items-center gap-1">
+          <button @click="handleExpandClick" class="p-2 hover:bg-gray-100 rounded transition-all">
+             <Maximize2 class="w-5 h-5 text-[#2C2C2C]" stroke-width="2.5" />
           </button>
+          
+          <div class="relative" ref="headerDropdownContainer">
+            <button @click="showDropdown = !showDropdown" class="p-2 hover:bg-gray-100 rounded transition-all">
+              <MoreHorizontal class="w-6 h-6 text-[#2C2C2C]" stroke-width="2.5" />
+            </button>
 
           <div v-if="showDropdown" class="absolute right-0 top-full mt-2 w-40 bg-white border-[2px] border-[#2C2C2C] rounded-lg shadow-[4px_4px_0px_0px_rgba(44,44,44,0.2)] overflow-hidden z-20">
             <button @click="handleShare" class="w-full px-4 py-2.5 flex items-center gap-2 hover:bg-gray-50 transition-colors text-left">
@@ -85,6 +90,7 @@
               </button>
             </template>
           </div>
+        </div>
         </div>
       </div>
 
@@ -295,7 +301,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watchEffect, reactive, watch } from 'vue'
-import { Calendar, MapPin, Edit, ListChecks, Shield, ChevronDown, Pencil, User, Heart, MessageCircle, Trash, MoreHorizontal, Share, Trash2 } from 'lucide-vue-next'
+import { Calendar, MapPin, Edit, ListChecks, Shield, ChevronDown, Pencil, User, Heart, MessageCircle, Trash, MoreHorizontal, Share, Trash2, Maximize2 } from 'lucide-vue-next'
 import KakaoMap from '@/components/common/KakaoMap.vue'
 import PlaceDetailPanel from '@/components/trip/PlaceDetailPanel.vue'
 import PlaceDetailModal from '@/components/modal/PlaceDetailModal.vue'
@@ -601,6 +607,12 @@ const handleMarkerClick = (id: number | string) => {
 const handleOpenPlaceDetailModal = (place: SpotResponseDto) => {
     detailedPlace.value = place
     showPlaceDetailModal.value = true
+}
+
+const handleExpandClick = () => {
+  if (tripLog.value) {
+    router.push({ name: 'trip-log-detail', params: { logId: tripLog.value.logId } })
+  }
 }
 
 const displayDuration = computed(() => {

--- a/src/components/modal/TripDetailModal.vue
+++ b/src/components/modal/TripDetailModal.vue
@@ -307,7 +307,7 @@ import type { TripLogDetail } from '@/types/trip/trip.model'
 import { getTripLogDetail, deleteTripLog, getTripLogLikeStatus } from '@/apis/trip-log/index'
 import AlertDialog from '@/components/common/AlertDialog.vue'
 import { handleImageError } from '@/utils/imageHandler'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 
 interface DayPlanDisplay {
@@ -330,6 +330,7 @@ const emit = defineEmits(['close', 'edit', 'write', 'edit-log', 'refresh', 'upda
 
 
 const router = useRouter()
+const route = useRoute()
 const authStore = useAuthStore()
 
 // 1. 상태 동기화 (드롭다운 즉시 반응용)
@@ -340,7 +341,7 @@ watchEffect(() => {
 
 // 2. 탭 & 로그 상태
 // 2. 탭 & 로그 상태
-const activeTab = ref<'map' | 'log'>(props.initialTab)
+const activeTab = ref<'map' | 'log'>((route.query.tab as 'map' | 'log') || props.initialTab || 'map')
 const tripLog = ref<TripLogDetail | null>(props.logData || null)
 const isLoginAlertVisible = ref(false)
 
@@ -469,8 +470,18 @@ const handleLogPlaceClick = (placeId: number) => {
 
 // 탭 핸들러
 const handleTabClick = (tab: 'map' | 'log') => {
-    activeTab.value = tab;
+  activeTab.value = tab
+  router.replace({ query: { ...route.query, tab } })
 }
+
+// URL 변경 감지 (뒤로가기 등)
+watch(() => route.query.tab, (newTab) => {
+  if (newTab === 'map' || newTab === 'log') {
+    activeTab.value = newTab
+  } else {
+    activeTab.value = 'map'
+  }
+})
 
 // 탭 변경 감지 및 로그 데이터 로드
 watch(activeTab, (newTab) => {
@@ -636,7 +647,6 @@ const navigateToUserLog = (userId: number) => {
   
   if (targetId) {
     router.push({ name: 'user-log', params: { userId: targetId } })
-    emit('close')
   } else {
     console.warn('Navigation failed: Missing author ID')
   }

--- a/src/components/modal/TripDetailModal.vue
+++ b/src/components/modal/TripDetailModal.vue
@@ -46,7 +46,7 @@
 
       <!-- Log Header -->
       <div v-if="activeTab === 'log' && tripLog" class="px-6 py-5 flex-shrink-0 rounded-t-xl z-20 border-[3px] border-[#2C2C2C] border-b-0 bg-white bg-gradient-to-br from-[#FFD60A]/10 to-white flex items-center justify-between">
-        <div class="flex items-center gap-3 cursor-pointer hover:opacity-80 transition-opacity" @click="navigateToUserLog(tripLog.authorId)">
+        <div class="flex items-center gap-3 cursor-pointer hover:opacity-80 transition-opacity w-fit" @click.stop="navigateToUserLog(tripLog.authorId)">
           <div class="w-12 h-12 border-[2px] border-[#2C2C2C] rounded-full overflow-hidden shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]">
             <img :src="tripLog.authorImageUrl" :alt="tripLog.authorNickname" class="w-full h-full object-cover" @error="handleImageError($event, 'profile')" />
           </div>
@@ -327,7 +327,10 @@ const props = withDefaults(defineProps<{
 })
 
 const emit = defineEmits(['close', 'edit', 'write', 'edit-log', 'refresh', 'update'])
+
+
 const router = useRouter()
+const authStore = useAuthStore()
 
 // 1. 상태 동기화 (드롭다운 즉시 반응용)
 const localTrip = reactive({ ...props.trip })
@@ -629,9 +632,13 @@ const handleBackdropClick = (e: MouseEvent) => {
 }
 
 const navigateToUserLog = (userId: number) => {
-  if (userId) {
-    router.push({ name: 'user-log', params: { userId } })
+  const targetId = userId || (props.trip.isOwner && authStore.user?.id);
+  
+  if (targetId) {
+    router.push({ name: 'user-log', params: { userId: targetId } })
     emit('close')
+  } else {
+    console.warn('Navigation failed: Missing author ID')
   }
 }
 </script>

--- a/src/components/modal/TripDetailModal.vue
+++ b/src/components/modal/TripDetailModal.vue
@@ -46,7 +46,7 @@
 
       <!-- Log Header -->
       <div v-if="activeTab === 'log' && tripLog" class="px-6 py-5 flex-shrink-0 rounded-t-xl z-20 border-[3px] border-[#2C2C2C] border-b-0 bg-white bg-gradient-to-br from-[#FFD60A]/10 to-white flex items-center justify-between">
-        <div class="flex items-center gap-3">
+        <div class="flex items-center gap-3 cursor-pointer hover:opacity-80 transition-opacity" @click="navigateToUserLog(tripLog.authorId)">
           <div class="w-12 h-12 border-[2px] border-[#2C2C2C] rounded-full overflow-hidden shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]">
             <img :src="tripLog.authorImageUrl" :alt="tripLog.authorNickname" class="w-full h-full object-cover" @error="handleImageError($event, 'profile')" />
           </div>
@@ -624,6 +624,13 @@ const handleClickOutside = (e: MouseEvent) => {
 
 const handleBackdropClick = (e: MouseEvent) => {
   if (e.target === e.currentTarget) {
+    emit('close')
+  }
+}
+
+const navigateToUserLog = (userId: number) => {
+  if (userId) {
+    router.push({ name: 'user-log', params: { userId } })
     emit('close')
   }
 }

--- a/src/components/trip-log/TripLogComments.vue
+++ b/src/components/trip-log/TripLogComments.vue
@@ -1,0 +1,283 @@
+<template>
+  <div class="bg-white flex flex-col h-full">
+    <!-- Header (Optional) -->
+    <div v-if="header" class="p-4 border-b border-gray-200 flex items-center justify-center relative">
+        <h3 class="font-black text-lg text-[#2C2C2C]">{{ header }}</h3>
+        <!-- Close button if needed passed via slot or event, but usually external control -->
+    </div>
+
+    <!-- Comments List -->
+    <div class="flex-1 overflow-y-auto p-4 space-y-4">
+      <template v-if="comments && comments.length > 0">
+        <div v-for="comment in comments" :key="comment.commentId" class="flex items-start gap-3">
+          <div
+            class="border-[2px] border-[#2C2C2C] rounded-full overflow-hidden flex-shrink-0 shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)] cursor-pointer hover:opacity-80"
+            :class="layout === 'horizontal' ? 'w-8 h-8' : 'w-10 h-10'"
+            @click="emit('navigate-user', comment.authorId)"
+          >
+            <img :src="comment.authorImageUrl" :alt="comment.authorNickname" class="w-full h-full object-cover" />
+          </div>
+          <div class="flex-1 min-w-0 flex items-start">
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2 mb-1">
+                <span 
+                  class="font-black text-[#2C2C2C] cursor-pointer hover:underline"
+                  :class="layout === 'horizontal' ? 'text-xs' : 'text-sm'"
+                  @click="emit('navigate-user', comment.authorId)"
+                >
+                  {{ comment.authorNickname }}
+                </span>
+                <span class="font-bold text-gray-400" :class="layout === 'horizontal' ? 'text-[10px]' : 'text-xs'">{{ formatCommentDate(comment.createdAt) }}</span>
+              </div>
+
+              <div v-if="editingCommentId === comment.commentId" class="flex flex-col gap-2">
+                 <input
+                    v-model="editingContent"
+                    type="text"
+                    ref="editInputRef"
+                    class="w-full border-[2px] border-[#2C2C2C] rounded-lg px-3 py-2 font-medium bg-white focus:outline-none focus:ring-1 focus:ring-[#2C2C2C]"
+                    :class="layout === 'horizontal' ? 'text-xs' : 'text-sm'"
+                    @keydown.enter.prevent="handleEditKeydown($event, comment.commentId)"
+                    @keydown.esc="cancelEditComment"
+                  />
+                  <div class="flex justify-end gap-2">
+                    <button @click="cancelEditComment" class="text-xs font-bold text-gray-500 hover:text-gray-700">취소</button>
+                    <button @click="handleUpdateComment(comment.commentId)" class="text-xs font-bold text-blue-500 hover:text-blue-700">저장</button>
+                  </div>
+              </div>
+              <p v-else :class="['font-medium text-gray-800 leading-relaxed break-all', layout === 'horizontal' ? 'text-xs' : 'text-sm']">{{ comment.content }}</p>
+            </div>
+
+            <div v-if="currentUserNickname === comment.authorNickname && editingCommentId !== comment.commentId" class="relative ml-2 flex-shrink-0">
+              <button 
+                @click.stop="toggleCommentDropdown(comment.commentId)"
+                class="p-1 hover:bg-gray-100 rounded-full transition-colors -mt-1"
+                :data-comment-dropdown-trigger="comment.commentId"
+              >
+                <MoreHorizontal class="w-4 h-4 text-gray-400" stroke-width="2" />
+              </button>
+              
+              <div
+                v-if="activeCommentDropdownId === comment.commentId"
+                class="absolute right-0 top-full mt-1 w-20 bg-white border-[2px] border-[#2C2C2C] rounded-lg shadow-[4px_4px_0px_0px_rgba(44,44,44,0.2)] overflow-hidden z-10"
+                :data-comment-dropdown-menu="comment.commentId"
+              >
+                <button
+                  @click="handleEditClick(comment)"
+                  class="w-full px-3 py-2 flex items-center justify-center hover:bg-gray-50 transition-colors text-xs font-bold text-[#2C2C2C] border-b border-gray-100"
+                >
+                  수정
+                </button>
+                <button
+                  @click="handleDeleteClick(comment.commentId)"
+                  class="w-full px-3 py-2 flex items-center justify-center hover:bg-red-50 transition-colors text-xs font-bold text-red-500"
+                >
+                  삭제
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+      <div v-else class="h-full flex flex-col items-center justify-center text-center opacity-60 min-h-[200px]">
+          <MessageCircle class="w-12 h-12 mb-2 text-gray-300" stroke-width="1.5" />
+          <p class="text-sm font-bold text-gray-400">댓글이 아직 없어요</p>
+          <p class="text-xs text-gray-400">첫 번째 댓글을 남겨보세요!</p>
+      </div>
+    </div>
+
+    <!-- Input Section -->
+    <div class="border-t border-gray-200 bg-white">
+      <slot name="footer-actions" />
+      
+      <div class="p-4" :class="{'pt-0': $slots['footer-actions']}">
+        <form @submit.prevent="handleCommentSubmit" class="flex items-center gap-2.5">
+          <div 
+            :class="[
+              'border-[2px] border-[#2C2C2C] rounded-full overflow-hidden flex-shrink-0 shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]',
+              layout === 'horizontal' ? 'w-8 h-8' : 'w-10 h-10'
+            ]"
+          >
+           <img
+            v-if="isLoggedIn && currentUserProfileImage"
+            :src="currentUserProfileImage"
+            alt="My Profile"
+            class="w-full h-full object-cover"
+          />
+          <img
+            v-else
+            src="/default-profile.svg"
+            alt="Default Profile"
+            class="w-full h-full object-cover"
+          />
+        </div>
+        <div class="relative flex-1">
+          <input
+            v-model="newComment"
+            :disabled="!isLoggedIn"
+            type="text"
+            :placeholder="
+              isLoggedIn ? '댓글을 입력하세요...' : '로그인 후 댓글을 남길 수 있습니다.'
+            "
+            class="w-full border-[2px] border-[#2C2C2C] rounded-lg font-medium bg-white focus:outline-none focus:shadow-[2px_2px_0px_0px_rgba(107,143,212,0.3)] transition-all placeholder:text-gray-400"
+            :class="[
+              !isLoggedIn ? 'bg-gray-100' : '',
+              layout === 'horizontal' ? 'px-3 py-2 text-xs' : 'px-4 py-3 text-sm'
+            ]"
+            @keydown.enter.prevent="handleKeydownSubmit"
+            ref="mainInputRef"
+          />
+          <div
+            v-if="!isLoggedIn"
+            @click="emit('login-required')"
+            class="absolute inset-0 cursor-pointer"
+          ></div>
+        </div>
+        <button
+          type="submit"
+          :disabled="!isLoggedIn"
+          :class="[
+            'border-[2px] border-[#2C2C2C] rounded-lg font-black bg-[#F9CA6B] text-[#2C2C2C] hover:shadow-[3px_3px_0px_0px_rgba(44,44,44,0.15)] hover:translate-x-[-1px] hover:translate-y-[-1px] transition-all uppercase tracking-wide disabled:opacity-50 disabled:cursor-not-allowed',
+            layout === 'horizontal' ? 'px-3 py-2 text-[10px]' : 'px-5 py-3 text-xs'
+          ]"
+        >
+          작성
+        </button>
+      </form>
+    </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, nextTick, onMounted, onUnmounted } from 'vue'
+import { MoreHorizontal, MessageCircle } from 'lucide-vue-next'
+import { format, parseISO } from 'date-fns'
+import type { TripLogCommentResponse } from '@/apis/trip-log/types'
+
+const props = withDefaults(defineProps<{
+  comments: TripLogCommentResponse[]
+  currentUserNickname?: string
+  currentUserProfileImage?: string
+  isLoggedIn: boolean
+  header?: string
+  layout?: 'vertical' | 'horizontal'
+}>(), {
+  layout: 'vertical'
+})
+
+const emit = defineEmits<{
+  (e: 'post-comment', content: string): void
+  (e: 'update-comment', id: number, content: string): void
+  (e: 'delete-comment', id: number): void
+  (e: 'login-required'): void
+  (e: 'navigate-user', userId: number): void
+}>()
+
+const newComment = ref('')
+const activeCommentDropdownId = ref<number | null>(null)
+const editingCommentId = ref<number | null>(null)
+const editingContent = ref('')
+const editInputRef = ref<HTMLInputElement | null>(null)
+const mainInputRef = ref<HTMLInputElement | null>(null)
+
+const handleCommentSubmit = () => {
+  if (!props.isLoggedIn) {
+     emit('login-required')
+    return
+  }
+  if (!newComment.value.trim()) return
+  emit('post-comment', newComment.value)
+  newComment.value = ''
+}
+
+const handleKeydownSubmit = (e: KeyboardEvent) => {
+  if (e.isComposing) return
+  handleCommentSubmit()
+}
+
+const startEditComment = async (comment: TripLogCommentResponse) => {
+  editingCommentId.value = comment.commentId
+  editingContent.value = comment.content
+  await nextTick()
+  if (editInputRef.value) {
+    editInputRef.value.focus()
+  }
+}
+
+const handleEditKeydown = (e: KeyboardEvent, commentId: number) => {
+  if (e.isComposing) return
+  handleUpdateComment(commentId)
+}
+
+const cancelEditComment = () => {
+  editingCommentId.value = null
+  editingContent.value = ''
+}
+
+const handleUpdateComment = async (commentId: number) => {
+  if (!editingContent.value.trim()) return
+  emit('update-comment', commentId, editingContent.value)
+  editingCommentId.value = null
+  editingContent.value = ''
+}
+
+const handleEditClick = (comment: TripLogCommentResponse) => {
+  activeCommentDropdownId.value = null
+  startEditComment(comment)
+}
+
+const handleDeleteClick = (commentId: number) => {
+  activeCommentDropdownId.value = null
+  emit('delete-comment', commentId)
+}
+
+const toggleCommentDropdown = (commentId: number) => {
+  if (activeCommentDropdownId.value === commentId) {
+    activeCommentDropdownId.value = null
+  } else {
+    activeCommentDropdownId.value = commentId
+  }
+}
+
+const formatCommentDate = (dateString: string) => {
+  const date = parseISO(dateString)
+  const now = new Date()
+  const diffSeconds = Math.round((now.getTime() - date.getTime()) / 1000)
+  if (diffSeconds < 60) return `${diffSeconds}초 전`
+  const diffMinutes = Math.round(diffSeconds / 60)
+  if (diffMinutes < 60) return `${diffMinutes}분 전`
+  const diffHours = Math.round(diffMinutes / 60)
+  if (diffHours < 24) return `${diffHours}시간 전`
+  return format(date, 'yyyy.MM.dd')
+}
+
+// Click outside logic
+const handleClickOutside = (e: MouseEvent) => {
+  if (activeCommentDropdownId.value !== null) {
+    const target = e.target as HTMLElement
+    const trigger = target.closest(`[data-comment-dropdown-trigger="${activeCommentDropdownId.value}"]`)
+    const menu = target.closest(`[data-comment-dropdown-menu="${activeCommentDropdownId.value}"]`)
+    
+    if (!trigger && !menu) {
+      activeCommentDropdownId.value = null
+    }
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
+
+defineExpose({
+    focusInput: () => mainInputRef.value?.focus()
+})
+</script>
+
+<style scoped>
+/* Scoped styles */
+</style>

--- a/src/components/trip-log/TripLogContent.vue
+++ b/src/components/trip-log/TripLogContent.vue
@@ -71,7 +71,7 @@
 
       <!-- Content Body -->
       <div class="p-5 border-b border-gray-200">
-        <h3 class="font-black text-lg mb-2 text-[#2C2C2C] font-sans">{{ logDetail.title }}</h3>
+        <h3 v-if="!hideTitle" class="font-black text-lg mb-2 text-[#2C2C2C] font-sans">{{ logDetail.title }}</h3>
 
         <div v-if="groupedCourse.length > 0" class="mb-4">
           <!-- Tabs -->
@@ -129,197 +129,154 @@
     </div>
 
     <!-- Comments & Footer Section (Right in Horizontal) -->
-    <div :class="[
+    <div 
+      v-if="!hideComments"
+      :class="[
       layout === 'horizontal' 
         ? 'w-[35%] h-full flex flex-col border-l border-gray-200' 
         : 'flex-1 flex flex-col min-h-0'
-    ]">
-      <!-- Comments List -->
-      <div class="flex-1 overflow-y-auto p-4 pt-3 space-y-4">
-        <template v-if="logDetail.comments && logDetail.comments.length > 0">
-          <div v-for="comment in logDetail.comments" :key="comment.commentId" class="flex items-start gap-3">
-            <div
-              :class="[
-                'border-[2px] border-[#2C2C2C] rounded-full overflow-hidden flex-shrink-0 shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)] cursor-pointer hover:opacity-80',
-                layout === 'horizontal' ? 'w-8 h-8' : 'w-10 h-10'
-              ]"
-              @click="navigateToUserLog(comment.authorId)"
-            >
-              <img :src="comment.authorImageUrl" :alt="comment.authorNickname" class="w-full h-full object-cover" />
-            </div>
-            <div class="flex-1 min-w-0 flex items-start">
-              <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2 mb-1">
-                  <span 
-                    :class="['font-black text-[#2C2C2C] cursor-pointer hover:underline', layout === 'horizontal' ? 'text-xs' : 'text-sm']"
-                    @click="navigateToUserLog(comment.authorId)"
-                  >
-                    {{ comment.authorNickname }}
-                  </span>
-                  <span :class="['font-bold text-gray-400', layout === 'horizontal' ? 'text-[10px]' : 'text-xs']">{{ formatCommentDate(comment.createdAt) }}</span>
-                </div>
-
-                <div v-if="editingCommentId === comment.commentId" class="flex flex-col gap-2">
-                   <input
-                      v-model="editingContent"
-                      type="text"
-                      ref="editInputRef"
-                      class="w-full border-[2px] border-[#2C2C2C] rounded-lg px-3 py-2 text-sm font-medium bg-white focus:outline-none focus:ring-1 focus:ring-[#2C2C2C]"
-                      @keydown.enter.prevent="handleEditKeydown($event, comment.commentId)"
-                      @keydown.esc="cancelEditComment"
-                    />
-                    <div class="flex justify-end gap-2">
-                      <button @click="cancelEditComment" class="text-xs font-bold text-gray-500 hover:text-gray-700">취소</button>
-                      <button @click="handleUpdateComment(comment.commentId)" class="text-xs font-bold text-blue-500 hover:text-blue-700">저장</button>
-                    </div>
-                </div>
-                <p v-else :class="['font-medium text-gray-800 leading-relaxed break-all', layout === 'horizontal' ? 'text-xs' : 'text-sm']">{{ comment.content }}</p>
-              </div>
-
-              <div v-if="authStore.user?.nickname === comment.authorNickname && editingCommentId !== comment.commentId" class="relative ml-2 flex-shrink-0">
-                <button 
-                  @click.stop="toggleCommentDropdown(comment.commentId)"
-                  class="p-1 hover:bg-gray-100 rounded-full transition-colors -mt-1"
-                  :data-comment-dropdown-trigger="comment.commentId"
-                >
-                  <MoreHorizontal class="w-4 h-4 text-gray-400" stroke-width="2" />
-                </button>
-                
-                <div
-                  v-if="activeCommentDropdownId === comment.commentId"
-                  class="absolute right-0 top-full mt-1 w-20 bg-white border-[2px] border-[#2C2C2C] rounded-lg shadow-[4px_4px_0px_0px_rgba(44,44,44,0.2)] overflow-hidden z-10"
-                  :data-comment-dropdown-menu="comment.commentId"
-                >
-                  <button
-                    @click="handleEditClick(comment)"
-                    class="w-full px-3 py-2 flex items-center justify-center hover:bg-gray-50 transition-colors text-xs font-bold text-[#2C2C2C] border-b border-gray-100"
-                  >
-                    수정
-                  </button>
-                  <button
-                    @click="handleDeleteClick(comment.commentId)"
-                    class="w-full px-3 py-2 flex items-center justify-center hover:bg-red-50 transition-colors text-xs font-bold text-red-500"
-                  >
-                    삭제
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </template>
-        <div v-else class="h-full flex flex-col items-center justify-center text-center opacity-60">
-            <MessageCircle class="w-12 h-12 mb-2 text-gray-300" stroke-width="1.5" />
-            <p class="text-sm font-bold text-gray-400">댓글이 아직 없어요</p>
-            <p class="text-xs text-gray-400">첫 번째 댓글을 남겨보세요!</p>
-        </div>
-      </div>
-
-      <!-- Footer: Actions & Input -->
-      <div class="border-t border-gray-200 bg-white">
-        <div class="p-4 flex items-center gap-2">
-          <button
-            @click="handleLike"
-            :class="[
-              'flex items-center gap-1.5 border-[2px] border-[#2C2C2C] rounded-full font-black text-xs transition-all uppercase',
-              layout === 'horizontal' ? 'px-3 py-1.5' : 'px-4 py-2.5',
-              isLiked
-                ? 'bg-[#FF6B9D] text-white shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]'
-                : 'bg-white hover:bg-gray-50 hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]',
-            ]"
-          >
-            <Heart :class="[layout === 'horizontal' ? 'w-3.5 h-3.5' : 'w-4 h-4', isLiked ? 'fill-current' : '']" stroke-width="2.5" />
-            <span>{{ currentLikes }}</span>
-          </button>
-
-          <button
-            @click="handleScrap"
-            :disabled="isScrapping"
-            :class="[
-              'flex items-center justify-center border-[2px] border-[#2C2C2C] rounded-full transition-all focus:outline-none',
-              layout === 'horizontal' ? 'w-8 h-8' : 'w-10 h-10',
-              isBookmarked
-                ? 'bg-[#98D8C8] shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]'
-                : 'bg-white hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]',
-              isScrapping && 'opacity-50 cursor-not-allowed',
-            ]"
-          >
-            <Bookmark
-              :class="[layout === 'horizontal' ? 'w-4 h-4' : 'w-5 h-5', isBookmarked ? 'text-[#2C2C2C] fill-[#2C2C2C]' : 'text-[#2C2C2C]']"
-              stroke-width="2.5"
-            />
-          </button>
-
-          <button
-            @click="handleShare"
-            :class="[
-              'flex items-center justify-center border-[2px] border-[#2C2C2C] rounded-full bg-white hover:bg-gray-50 hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)] transition-all focus:outline-none',
-              layout === 'horizontal' ? 'w-8 h-8' : 'w-10 h-10'
-            ]"
-          >
-            <Share2
-              :class="[layout === 'horizontal' ? 'w-4 h-4' : 'w-5 h-5', 'text-[#2C2C2C]']"
-              stroke-width="2.5"
-            />
-          </button>
-        </div>
-
-        <div class="p-4 pt-0">
-          <form @submit.prevent="handleCommentSubmit" class="flex items-center gap-2.5">
-            <div
-              :class="[
-                'border-[2px] border-[#2C2C2C] rounded-full overflow-hidden flex-shrink-0 shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]',
-                layout === 'horizontal' ? 'w-8 h-8' : 'w-10 h-10'
-              ]"
-            >
-               <img
-                v-if="authStore.isLoggedIn && authStore.user?.profileImageUrl"
-                :src="authStore.user.profileImageUrl"
-                alt="My Profile"
-                class="w-full h-full object-cover"
-              />
-              <img
-                v-else
-                src="/default-profile.svg"
-                alt="Default Profile"
-                class="w-full h-full object-cover"
-              />
-            </div>
-            <div class="relative flex-1">
-              <input
-                v-model="newComment"
-                :disabled="!authStore.isLoggedIn"
-                type="text"
-                :placeholder="
-                  authStore.isLoggedIn ? '댓글을 입력하세요...' : '로그인 후 댓글을 남길 수 있습니다.'
-                "
+     ]"
+    >
+      <TripLogComments 
+        :comments="logDetail.comments"
+        :current-user-nickname="authStore.user?.nickname"
+        :current-user-profile-image="authStore.user?.profileImageUrl"
+        :is-logged-in="authStore.isLoggedIn"
+        @post-comment="handlePostComment"
+        @update-comment="handleUpdateComment"
+        @delete-comment="handleDeleteComment"
+        @login-required="emit('login-required')"
+        @navigate-user="navigateToUserLog"
+        :layout="layout"
+        class="flex-1 min-h-0"
+      >
+        <template #footer-actions>
+           <div class="p-4 py-3 flex items-center gap-2">
+              <!-- Like Button -->
+              <button 
+                @click="handleLike" 
                 :class="[
-                  'w-full border-[2px] border-[#2C2C2C] rounded-lg font-medium bg-white focus:outline-none focus:shadow-[2px_2px_0px_0px_rgba(107,143,212,0.3)] transition-all placeholder:text-gray-400',
-                  layout === 'horizontal' ? 'px-3 py-2 text-xs' : 'px-4 py-3 text-sm',
-                  !authStore.isLoggedIn ? 'bg-gray-100' : '',
+                  'flex items-center gap-1.5 px-3 py-1.5 border-[2px] border-[#2C2C2C] rounded-full transition-all group',
+                  isLiked ? 'bg-[#FF6B9D] text-white shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]' : 'bg-white hover:bg-gray-50 hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]'
                 ]"
-                @keydown.enter.prevent="handleKeydownSubmit"
-              />
-              <div
-                v-if="!authStore.isLoggedIn"
-                @click="emit('login-required')"
-                class="absolute inset-0 cursor-pointer"
-              ></div>
-            </div>
-            <button
-              type="submit"
-              :disabled="!authStore.isLoggedIn"
-              :class="[
-                'border-[2px] border-[#2C2C2C] rounded-lg font-black bg-[#F9CA6B] text-[#2C2C2C] hover:shadow-[3px_3px_0px_0px_rgba(44,44,44,0.15)] hover:translate-x-[-1px] hover:translate-y-[-1px] transition-all uppercase tracking-wide disabled:opacity-50 disabled:cursor-not-allowed',
-                layout === 'horizontal' ? 'px-3 py-2 text-[10px]' : 'px-5 py-3 text-xs'
-              ]"
-            >
-              작성
-            </button>
-          </form>
-        </div>
-      </div>
+              >
+                <Heart 
+                  :class="['w-4 h-4 transition-all', isLiked ? 'fill-white text-white' : 'text-[#2C2C2C]']" 
+                  stroke-width="2.5" 
+                />
+                <span 
+                  class="text-xs font-black"
+                  :class="isLiked ? 'text-white' : 'text-[#2C2C2C]'"
+                >
+                  {{ currentLikes }}
+                </span>
+              </button>
+              
+              <!-- Scrap Button -->
+              <button 
+                @click="handleScrap" 
+                :class="[
+                  'flex items-center justify-center p-1.5 border-[2px] border-[#2C2C2C] rounded-full transition-all group',
+                  isBookmarked ? 'bg-[#FFD60A] shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]' : 'bg-white hover:bg-gray-50 hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]'
+                ]"
+              >
+                <Bookmark 
+                  :class="['w-4 h-4 transition-all', isBookmarked ? 'fill-white text-white' : 'text-[#2C2C2C]']" 
+                  stroke-width="2.5" 
+                />
+              </button>
+
+               <!-- Share Button -->
+               <button 
+                @click="handleShare" 
+                class="flex items-center justify-center p-1.5 border-[2px] border-[#2C2C2C] rounded-full bg-white hover:bg-gray-50 hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)] transition-all group"
+              >
+                 <Share2 class="w-4 h-4 text-[#2C2C2C]" stroke-width="2.5" />
+               </button>
+           </div>
+        </template>
+      </TripLogComments>
+
+       <!-- Footer Actions (Like, Scrap, Share) - Re-added here if TripLogComments is primarily for list+input but Like is distinct -->
+       <!-- Wait, I moved Like/Scrap into Footer in previous version.
+            TripLogComments handles comments list and input.
+            But Like/Scrap logic was separate.
+            If I want to reuse TripLogComments purely for comments, I should keep Like/Scrap here OR move them to TripLogComments.
+            The user request said "좋아요 댓글 버튼은 처음엔 안 보였다가...". This implies View mode manages Like button visibility.
+            BUT Modal mode needs Like button visible as footer.
+            
+            If I put Like button in TripLogComments, it will show in Drawer (as Header or Footer?).
+            TripLogComments design just has list and input.
+            
+            In MODAL mode: We want Like button fixed at bottom or top of footer?
+            The previous code had Like/Scrap/Share in a Footer div ABOVE the Input form.
+            TripLogComments has Input form at bottom.
+            I should probably inject the Like/Scrap buttons via slot or keep them outside TripLogComments if layouts differ significantly.
+            
+            However, for the Modal, the layout is:
+            [Comments List]
+            [Like/Scrap Row]
+            [Input Form]
+            
+            TripLogComments currently implements:
+            [Comments List]
+            [Input Form] -- Wait, I missed the Like/Scrap row in TripLogComments in step 997.
+            
+            Let's re-read TripLogComments created in 997.
+            It has:
+            1. Comments List
+            2. Input Section
+            
+            It MISSES the Like/Scrap/Share row that was present in `TripLogContent`.
+            
+            So, `TripLogContent` (in Modal) needs to render Like/Scrap/Share row.
+            Where? Between List and Input?
+            `TripLogComments` doesn't support slot between List and Input easily unless I modify it.
+            
+            Alternatively, I can pass `showFooterActions` prop to `TripLogComments` and implement them there.
+            But `TripLogComments` is reused in Drawer where we might NOT want Like button inside the drawer (since floating bar has it).
+            
+            Actually, the Drawer is for "Seeing comments". It probably should just be comments.
+            The Like button is on the Floating Bar.
+            So `TripLogComments` handles List + Input is correct for Drawer.
+            
+            For Modal (TripLogContent):
+            It needs Like/Scrap buttons.
+            I can put them *above* `TripLogComments`? No, they were *below* list, above input.
+            
+            I will modify `TripLogComments` to check if I can insert them.
+            OR I can leave `TripLogComments` as is, and `TripLogContent` renders:
+            [Comments List (via TripLogComments - List Only?)]
+            
+            Refactoring strategy adjust:
+            `TripLogContent` needs to maintain Modal appearance.
+            Modal appearance: List -> Like Row -> Input.
+            
+            If I delegate everything to `TripLogComments`, it forces Drawer to have same layout?
+            Drawer usually: List -> Input. (Like is outside).
+            So `TripLogComments` matches Drawer.
+            
+            For Modal:
+            We want Like Row.
+            I can add a Slot to `TripLogComments` named `actions` just before the Input form.
+            Then `TripLogContent` provides the Like/Scrap buttons into that slot.
+            
+            Let's do that. I'll utilize `TripLogComments` with a slot.
+            Wait, I already wrote `TripLogComments` in step 997 without slot.
+            I should update `TripLogComments` to add `<slot name="actions" />` before `<form>`.
+            
+      -->
     </div>
     
+     <!-- If hideComments is true (Full Page View), we might still want the Like/Scrap buttons NOT to be here because they are in Floating Bar.
+          So `TripLogContent` logic removes the right column entirely if `hideComments` is true.
+          This matches requirements.
+          
+          Issues:
+          1. Modal loses Like/Scrap buttons because they were removed from `TripLogContent` template in this proposed file and not added to `TripLogComments`.
+          2. `TripLogComments` needs to support the Like/Scrap row for Modal usage.
+      -->
+
      <Transition
       enter-active-class="transition-all duration-300 ease-out"
       leave-active-class="transition-all duration-200 ease-in"
@@ -355,7 +312,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watchEffect, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, watchEffect, onMounted, onUnmounted } from 'vue'
 import {
   Heart,
   Bookmark,
@@ -366,16 +323,15 @@ import {
   Share2,
   Edit,
   Trash2,
-  MessageCircle,
 } from 'lucide-vue-next'
 import AlertDialog from '@/components/common/AlertDialog.vue'
+import TripLogComments from './TripLogComments.vue'
 import { format, parseISO } from 'date-fns'
 import type { TripLogDetail } from '@/types/trip/trip.model'
 import type { TripDetailResponseDto } from '@/apis/trip/types'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
-import { likeTripLog, unlikeTripLog, postTripLogComment, getTripLogDetail, getTripLogLikeStatus, updateTripLogComment, deleteTripLogComment } from '@/apis/trip-log/index'
-// import { requestScrapTrip } from '@/apis/trip/index'
+import { likeTripLog, unlikeTripLog, postTripLogComment, updateTripLogComment, deleteTripLogComment } from '@/apis/trip-log/index'
 
 const props = withDefaults(defineProps<{
   logDetail: TripLogDetail
@@ -383,9 +339,13 @@ const props = withDefaults(defineProps<{
   initialLiked: boolean
   showHeader?: boolean
   layout?: 'vertical' | 'horizontal'
+  hideTitle?: boolean
+  hideComments?: boolean
 }>(), {
   showHeader: true,
-  layout: 'vertical'
+  layout: 'vertical',
+  hideTitle: false,
+  hideComments: false
 })
 
 const emit = defineEmits(['update-like', 'place-click', 'login-required', 'refresh-comments', 'edit', 'delete'])
@@ -396,8 +356,7 @@ const router = useRouter()
 const showDropdown = ref(false)
 const showToast = ref(false)
 const activeDay = ref(1)
-const newComment = ref('')
-const isBookmarked = ref(false) // Local state for bookmark (Mock)
+const isBookmarked = ref(false) 
 const isLiked = ref(props.initialLiked)
 const currentLikes = ref(props.logDetail.likeCount)
 
@@ -436,19 +395,12 @@ const showAlert = (title: string, message: string) => {
   }
 }
 
-const activeCommentDropdownId = ref<number | null>(null)
-
-const editingCommentId = ref<number | null>(null)
-const editingContent = ref('')
-const editInputRef = ref<HTMLInputElement | null>(null)
-
-// Update local state when props change
 watchEffect(() => {
     isLiked.value = props.initialLiked
     currentLikes.value = props.logDetail.likeCount
 })
 
-const isAuthor = computed(() => props.logDetail.authorNickname === authStore.user?.nickname) // Adjust as needed
+const isAuthor = computed(() => props.logDetail.authorNickname === authStore.user?.nickname)
 
 const formattedDate = computed(() => {
   if (!props.logDetail.createdAt) return ''
@@ -517,14 +469,6 @@ const handleScrap = async () => {
 
   try {
     isScrapping.value = true
-    // const response = await requestScrapTrip(props.logDetail.logId)
-    // if (response.tripId) {
-    //   isBookmarked.value = true
-    //   showToast.value = true
-    //   setTimeout(() => {
-    //     showToast.value = false
-    //   }, 2500)
-    // }
     alert('아직 준비 중인 기능입니다!')
   } catch (err) {
     console.error('스크랩 실패:', err)
@@ -534,15 +478,9 @@ const handleScrap = async () => {
   }
 }
 
-const handleCommentSubmit = async () => {
-  if (!authStore.isLoggedIn) {
-     emit('login-required')
-    return
-  }
-  if (!newComment.value.trim()) return
+const handlePostComment = async (content: string) => {
   try {
-    await postTripLogComment(props.logDetail.logId, { content: newComment.value })
-    newComment.value = ''
+    await postTripLogComment(props.logDetail.logId, { content })
     emit('refresh-comments')
   } catch (error) {
     console.error('Failed to post comment:', error)
@@ -550,36 +488,9 @@ const handleCommentSubmit = async () => {
   }
 }
 
-const startEditComment = async (comment: any) => {
-  editingCommentId.value = comment.commentId
-  editingContent.value = comment.content
-  await nextTick()
-  if (editInputRef.value) {
-    editInputRef.value.focus()
-  }
-}
-
-const handleEditKeydown = (e: KeyboardEvent, commentId: number) => {
-  if (e.isComposing) return
-  handleUpdateComment(commentId)
-}
-
-const handleKeydownSubmit = (e: KeyboardEvent) => {
-  if (e.isComposing) return
-  handleCommentSubmit()
-}
-
-const cancelEditComment = () => {
-  editingCommentId.value = null
-  editingContent.value = ''
-}
-
-const handleUpdateComment = async (commentId: number) => {
-  if (!editingContent.value.trim()) return
+const handleUpdateComment = async (commentId: number, content: string) => {
   try {
-    await updateTripLogComment(commentId, { content: editingContent.value })
-    editingCommentId.value = null
-    editingContent.value = ''
+    await updateTripLogComment(commentId, { content })
     emit('refresh-comments')
   } catch (error) {
     console.error('Failed to update comment:', error)
@@ -622,71 +533,20 @@ const handleDelete = () => {
 const colors = ['#FFD60A', '#FF6B9D', '#98D8C8', '#B4E4FF', '#E88555']
 const getBadgeColor = (idx: number) => colors[idx % colors.length]
 
-const formatCommentDate = (dateString: string) => {
-  const date = parseISO(dateString)
-  const now = new Date()
-  const diffSeconds = Math.round((now.getTime() - date.getTime()) / 1000)
-  if (diffSeconds < 60) return `${diffSeconds}초 전`
-  const diffMinutes = Math.round(diffSeconds / 60)
-  if (diffMinutes < 60) return `${diffMinutes}분 전`
-  const diffHours = Math.round(diffMinutes / 60)
-  if (diffHours < 24) return `${diffHours}시간 전`
-  return format(date, 'yyyy.MM.dd')
-}
-
 const dropdownContainer = ref<HTMLElement | null>(null)
 
 const handleClickOutside = (e: MouseEvent) => {
-  // Main dropdown
   if (showDropdown.value && dropdownContainer.value && !dropdownContainer.value.contains(e.target as Node)) {
     showDropdown.value = false
-  }
-  
-  // Comment dropdowns
-  if (activeCommentDropdownId.value !== null) {
-    const target = e.target as HTMLElement
-    const trigger = target.closest(`[data-comment-dropdown-trigger="${activeCommentDropdownId.value}"]`)
-    const menu = target.closest(`[data-comment-dropdown-menu="${activeCommentDropdownId.value}"]`)
-    
-    if (!trigger && !menu) {
-      activeCommentDropdownId.value = null
-    }
-  }
-}
-
-const toggleCommentDropdown = (commentId: number) => {
-  if (activeCommentDropdownId.value === commentId) {
-    activeCommentDropdownId.value = null
-  } else {
-    activeCommentDropdownId.value = commentId
-  }
-}
-
-const handleEditClick = (comment: any) => {
-  activeCommentDropdownId.value = null
-  startEditComment(comment)
-}
-
-const handleDeleteClick = (commentId: number) => {
-  activeCommentDropdownId.value = null
-  handleDeleteComment(commentId)
-}
-
-const handleKeydown = (e: KeyboardEvent) => {
-  if (e.key === 'Escape') {
-    if (showDropdown.value) showDropdown.value = false
-    if (activeCommentDropdownId.value !== null) activeCommentDropdownId.value = null
   }
 }
 
 onMounted(() => {
   document.addEventListener('click', handleClickOutside)
-  document.addEventListener('keydown', handleKeydown)
 })
 
 onUnmounted(() => {
   document.removeEventListener('click', handleClickOutside)
-  document.removeEventListener('keydown', handleKeydown)
 })
 
 const navigateToUserLog = (userId: number) => {
@@ -694,7 +554,6 @@ const navigateToUserLog = (userId: number) => {
     router.push({ name: 'user-log', params: { userId } })
   } else {
     console.warn('작성자 ID가 없습니다. API 응답을 확인해주세요.')
-    // alert('정보가 부족하여 이동할 수 없습니다.') // Optional: User facing feedback
   }
 }
 </script>

--- a/src/components/trip-log/TripLogContent.vue
+++ b/src/components/trip-log/TripLogContent.vue
@@ -140,16 +140,22 @@
           <div v-for="comment in logDetail.comments" :key="comment.commentId" class="flex items-start gap-3">
             <div
               :class="[
-                'border-[2px] border-[#2C2C2C] rounded-full overflow-hidden flex-shrink-0 shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]',
+                'border-[2px] border-[#2C2C2C] rounded-full overflow-hidden flex-shrink-0 shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)] cursor-pointer hover:opacity-80',
                 layout === 'horizontal' ? 'w-8 h-8' : 'w-10 h-10'
               ]"
+              @click="navigateToUserLog(comment.authorId)"
             >
               <img :src="comment.authorImageUrl" :alt="comment.authorNickname" class="w-full h-full object-cover" />
             </div>
             <div class="flex-1 min-w-0 flex items-start">
               <div class="flex-1 min-w-0">
                 <div class="flex items-center gap-2 mb-1">
-                  <span :class="['font-black text-[#2C2C2C]', layout === 'horizontal' ? 'text-xs' : 'text-sm']">{{ comment.authorNickname }}</span>
+                  <span 
+                    :class="['font-black text-[#2C2C2C] cursor-pointer hover:underline', layout === 'horizontal' ? 'text-xs' : 'text-sm']"
+                    @click="navigateToUserLog(comment.authorId)"
+                  >
+                    {{ comment.authorNickname }}
+                  </span>
                   <span :class="['font-bold text-gray-400', layout === 'horizontal' ? 'text-[10px]' : 'text-xs']">{{ formatCommentDate(comment.createdAt) }}</span>
                 </div>
 
@@ -366,6 +372,7 @@ import AlertDialog from '@/components/common/AlertDialog.vue'
 import { format, parseISO } from 'date-fns'
 import type { TripLogDetail } from '@/types/trip/trip.model'
 import type { TripDetailResponseDto } from '@/apis/trip/types'
+import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { likeTripLog, unlikeTripLog, postTripLogComment, getTripLogDetail, getTripLogLikeStatus, updateTripLogComment, deleteTripLogComment } from '@/apis/trip-log/index'
 // import { requestScrapTrip } from '@/apis/trip/index'
@@ -384,6 +391,7 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits(['update-like', 'place-click', 'login-required', 'refresh-comments', 'edit', 'delete'])
 
 const authStore = useAuthStore()
+const router = useRouter()
 
 const showDropdown = ref(false)
 const showToast = ref(false)
@@ -680,6 +688,15 @@ onUnmounted(() => {
   document.removeEventListener('click', handleClickOutside)
   document.removeEventListener('keydown', handleKeydown)
 })
+
+const navigateToUserLog = (userId: number) => {
+  if (userId) {
+    router.push({ name: 'user-log', params: { userId } })
+  } else {
+    console.warn('작성자 ID가 없습니다. API 응답을 확인해주세요.')
+    // alert('정보가 부족하여 이동할 수 없습니다.') // Optional: User facing feedback
+  }
+}
 </script>
 
 <style scoped>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -68,7 +68,7 @@ const router = createRouter({
       path: '/log-write/:tripId',
       name: 'log-write',
       component: () => import('@/views/CreateTripLogView.vue'),
-      props:true
+      props: true
     },
     {
       path: '/friends',
@@ -79,7 +79,13 @@ const router = createRouter({
       path: '/log-edit/:logId',
       name: 'log-edit',
       component: () => import('@/views/EditTripLogView.vue'),
-      props:true
+      props: true
+    },
+    {
+      path: '/diary/:logId',
+      name: 'trip-log-detail',
+      component: () => import('@/views/TripLogDetailView.vue'),
+      props: true
     }
   ],
 })

--- a/src/types/trip/trip.model.ts
+++ b/src/types/trip/trip.model.ts
@@ -1,7 +1,7 @@
 import type { Place } from '@/types/trip/place.model'
 import type { TripLogCommentResponse } from '@/apis/trip-log/types'
 import type { TripResponseDto } from '@/apis/trip/types'
-import type { TripVisibility } from '@/types/trip/trip.model'
+
 
 /**
  * 여행 가시성 상태
@@ -24,27 +24,28 @@ export interface TripPlanItem {
  */
 
 export interface TripLogImage {
-    imageRefKey: string
-    imageUrl: string
-    orderIndex: number
+  imageRefKey: string
+  imageUrl: string
+  orderIndex: number
 }
 
 
 export interface TripLogDetail {
-logId: number
-title: string
-content: string
-locationSummary: string
-likeCount: number
-commentCount: number
-createdAt: string
-authorNickname: string
-authorImageUrl: string
-tripId: number
-tripTitle: string
-images: TripLogImage[]
-comments: TripLogCommentResponse[]
-visibility: TripVisibility
+  logId: number
+  title: string
+  content: string
+  locationSummary: string
+  likeCount: number
+  commentCount: number
+  createdAt: string
+  authorNickname: string
+  authorImageUrl: string
+  tripId: number
+  tripTitle: string
+  images: TripLogImage[]
+  comments: TripLogCommentResponse[]
+  visibility: TripVisibility
+  authorId: number
 }
 
 export interface TripDiaryView {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -242,6 +242,7 @@ const handleOpenTripLog = (logId: number) => {
 
 // Watch URL for modal state
 watch(() => route.query.logId, (newLogId) => {
+  console.log('HomeView: route.query.logId changed:', newLogId)
   if (newLogId) {
     selectedLogId.value = Number(newLogId)
     // authorId is not in URL, but if opening from feed, handleOpenLog sets it. 
@@ -253,8 +254,13 @@ watch(() => route.query.logId, (newLogId) => {
 }, { immediate: true })
 
 const handleOpenLogFromFeed = (payload: { logId: number, authorId: number }) => {
+  console.log('HomeView: handleOpenLogFromFeed called with', payload)
   selectedAuthorId.value = payload.authorId
   router.push({ query: { ...route.query, logId: payload.logId } })
+    .then(() => console.log('HomeView: router.push success'))
+    .catch(err => {
+      console.error('HomeView: router.push failed:', err)
+    })
 }
 
 const handleLogUpdate = (payload: { logId: number; likeCount: number; liked: boolean }) => {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -191,6 +191,7 @@
         :author-id="selectedAuthorId"
         @close="handleLogClose"
         @update="handleLogUpdate"
+        @edit="handleEditFromModal"
     />
 
     <TripDetailModal

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -81,7 +81,7 @@
           <!-- Feed Items -->
           <div class="space-y-8">
             <template v-for="diary in diaryEntries" :key="diary.logId">
-              <DiaryFeedItem v-bind="diary" />
+              <DiaryFeedItem v-bind="diary" @open-log="handleOpenLogFromFeed" />
             </template>
           </div>
 
@@ -188,6 +188,7 @@
     <DiaryCommentModal
         v-if="selectedLogId"
         :log-id="selectedLogId"
+        :author-id="selectedAuthorId"
         @close="handleLogClose"
         @update="handleLogUpdate"
     />
@@ -195,7 +196,7 @@
     <TripDetailModal
         v-if="selectedTrip"
         :trip="selectedTrip"
-        @close="selectedTrip = null"
+        @close="router.back()"
         @edit="handleEditFromModal"
     />
 
@@ -204,7 +205,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { ref, onMounted, onUnmounted, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useNavigate } from '@/composables/common/useNavagation'
 import TravelNavbar from '@/components/common/TravelNavbar.vue'
@@ -221,18 +222,38 @@ import { spotApi } from '@/apis/spot'
 import { getMyTrips, createTrip, getTripDetail } from '@/apis/trip' // Added getTripDetail
 import type { TripResponseDto } from '@/apis/trip/types'
 import { differenceInCalendarDays, isAfter, isSameDay, startOfDay, parseISO } from 'date-fns'
+import { useRoute } from 'vue-router'
 
 const router = useRouter()
+const route = useRoute()
 const { handleNavigate } = useNavigate()
 
 const selectedPlaceForDetail = ref<any>(null) // For PlaceDetailModal
 const placeDetailModalRef = ref<any>(null)
 const selectedLogId = ref<number | null>(null)
+const selectedAuthorId = ref<number | undefined>(undefined)
 const hasLogUpdates = ref(false)
 const selectedTrip = ref<any>(null)
 
 const handleOpenTripLog = (logId: number) => {
-    selectedLogId.value = logId
+    router.push({ query: { ...route.query, logId } })
+}
+
+// Watch URL for modal state
+watch(() => route.query.logId, (newLogId) => {
+  if (newLogId) {
+    selectedLogId.value = Number(newLogId)
+    // authorId is not in URL, but if opening from feed, handleOpenLog sets it. 
+    // If refreshing page, authorId will be undefined, but Modal handles fallback/missing ID.
+  } else {
+    selectedLogId.value = null
+    selectedAuthorId.value = undefined
+  }
+}, { immediate: true })
+
+const handleOpenLogFromFeed = (payload: { logId: number, authorId: number }) => {
+  selectedAuthorId.value = payload.authorId
+  router.push({ query: { ...route.query, logId: payload.logId } })
 }
 
 const handleLogUpdate = (payload: { logId: number; likeCount: number; liked: boolean }) => {
@@ -243,7 +264,7 @@ const handleLogUpdate = (payload: { logId: number; likeCount: number; liked: boo
 }
 
 const handleLogClose = () => {
-    selectedLogId.value = null
+    router.back()
     if (hasLogUpdates.value) {
         if (placeDetailModalRef.value) {
             placeDetailModalRef.value.refreshWithEffect()
@@ -252,7 +273,19 @@ const handleLogClose = () => {
     }
 }
 
-const handleNavigateToTrip = async (tripId: number) => {
+const handleNavigateToTrip = (tripId: number) => {
+    router.push({ query: { ...route.query, tripId } })
+}
+
+watch(() => route.query.tripId, async (newTripId) => {
+    if (newTripId) {
+        await fetchTripDetailAndOpen(Number(newTripId))
+    } else {
+        selectedTrip.value = null
+    }
+}, { immediate: true })
+
+const fetchTripDetailAndOpen = async (tripId: number) => {
     try {
         const detail = await getTripDetail(tripId)
         selectedTrip.value = {
@@ -268,6 +301,7 @@ const handleNavigateToTrip = async (tripId: number) => {
     } catch (error) {
         console.error('Failed to fetch trip detail:', error)
         alert('여행 정보를 불러오는데 실패했습니다.')
+        router.replace({ query: { ...route.query, tripId: undefined } })
     }
 }
 

--- a/src/views/TripLogDetailView.vue
+++ b/src/views/TripLogDetailView.vue
@@ -1,0 +1,179 @@
+<template>
+  <div class="min-h-screen bg-[#F5F5F5] font-sans">
+    <TravelNavbar @navigate="handleNavigate" />
+
+    <div class="pt-24 max-w-4xl mx-auto px-4 pb-20">
+      <div v-if="isLoading" class="flex justify-center items-center h-[60vh]">
+         <div class="w-12 h-12 border-[4px] border-[#2C2C2C] border-t-transparent rounded-full animate-spin"></div>
+      </div>
+
+      <div v-else-if="error" class="flex flex-col items-center justify-center h-[60vh] text-center">
+        <p class="text-xl font-black text-red-500 mb-4">{{ error }}</p>
+        <button
+          @click="router.back()"
+          class="px-6 py-2 bg-[#2C2C2C] text-white rounded-lg font-bold hover:bg-black transition-colors"
+        >
+          돌아가기
+        </button>
+      </div>
+
+      <div v-else-if="tripLog && tripDetail" class="bg-white rounded-xl shadow-[4px_4px_0px_0px_rgba(44,44,44,0.1)] overflow-hidden border-[2px] border-[#2C2C2C]">
+        <!-- Header -->
+        <div class="px-6 py-5 border-b-[2px] border-[#F0F0F0] bg-white flex items-center justify-between">
+           <div class="flex items-center gap-3 cursor-pointer hover:opacity-80 transition-opacity" @click="navigateToUserLog(tripLog!.authorId)">
+             <div class="w-12 h-12 border-[2px] border-[#2C2C2C] rounded-full overflow-hidden">
+               <img :src="tripLog.authorImageUrl" :alt="tripLog.authorNickname" class="w-full h-full object-cover" />
+             </div>
+             <div>
+                <h4 class="font-black text-lg text-[#2C2C2C]">{{ tripLog.authorNickname }}</h4>
+                <div class="flex items-center gap-2 text-xs font-bold text-gray-500">
+                  <span>{{ tripLog.locationSummary }}</span>
+                  <span>•</span>
+                  <span>{{ tripLog.createdAt.substring(0, 10) }}</span>
+                </div>
+             </div>
+           </div>
+           
+           <!-- Share Button -->
+           <button @click="handleShare" class="p-2 hover:bg-gray-100 rounded-lg transition-colors">
+              <Share2 class="w-5 h-5 text-[#2C2C2C]" />
+           </button>
+        </div>
+
+        <!-- Content -->
+        <div class="min-h-[500px]">
+          <TripLogContent
+            :log-detail="tripLog"
+            :trip-detail="tripDetail"
+            :initial-liked="isLiked"
+            :show-header="false"
+            layout="vertical"
+            @update-like="handleUpdateLike"
+            @login-required="isLoginAlertVisible = true"
+            @refresh-comments="fetchData"
+          />
+        </div>
+      </div>
+    </div>
+    
+    <AlertDialog
+      :is-open="isLoginAlertVisible"
+      title="로그인 필요"
+      message="로그인이 필요한 서비스입니다.\n로그인 페이지로 이동하시겠습니까?"
+      confirm-text="로그인"
+      cancel-text="취소"
+      @confirm="handleLoginConfirm"
+      @cancel="isLoginAlertVisible = false"
+      @close="isLoginAlertVisible = false"
+    />
+
+    <!-- Toast for copy link -->
+     <Transition
+      enter-active-class="transition-all duration-300 ease-out"
+      leave-active-class="transition-all duration-200 ease-in"
+      enter-from-class="opacity-0 translate-y-[-20px]"
+      enter-to-class="opacity-100 translate-y-0"
+      leave-from-class="opacity-100 translate-y-0"
+      leave-to-class="opacity-0 translate-y-[-20px]"
+    >
+      <div
+        v-if="showToast"
+        class="fixed top-24 right-6 z-[60] bg-white border-[3px] border-[#2C2C2C] rounded-xl shadow-[4px_4px_0px_0px_rgba(44,44,44,0.3)] px-5 py-3 flex items-center gap-3"
+      >
+         <span class="font-black text-sm text-[#2C2C2C]">링크가 복사되었습니다!</span>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import TravelNavbar from '@/components/common/TravelNavbar.vue'
+import TripLogContent from '@/components/trip-log/TripLogContent.vue'
+import AlertDialog from '@/components/common/AlertDialog.vue'
+import { useNavigate } from '@/composables/common/useNavagation'
+import { getTripLogDetail, getTripLogLikeStatus } from '@/apis/trip-log/index'
+import { getTripDetail } from '@/apis/trip/index'
+import { Share2 } from 'lucide-vue-next'
+import { useAuthStore } from '@/stores/auth'
+import type { TripLogDetail } from '@/types/trip/trip.model'
+import type { TripDetailResponseDto } from '@/apis/trip/types'
+
+const route = useRoute()
+const router = useRouter()
+const { handleNavigate } = useNavigate()
+const authStore = useAuthStore()
+
+const logId = Number(route.params.logId)
+const isLoading = ref(true)
+const error = ref<string | null>(null)
+const tripLog = ref<TripLogDetail | null>(null)
+const tripDetail = ref<TripDetailResponseDto | null>(null)
+const isLiked = ref(false)
+const isLoginAlertVisible = ref(false)
+const showToast = ref(false)
+
+const fetchData = async () => {
+    isLoading.value = true
+    error.value = null
+    try {
+        const [logRes, likeRes] = await Promise.all([
+            getTripLogDetail(logId),
+            authStore.user ? getTripLogLikeStatus(logId) : Promise.resolve({ liked: false })
+        ])
+        
+        tripLog.value = {
+            ...logRes,
+            logId: logId, // ensure ID
+             authorId: logRes.authorId || 0
+        }
+        isLiked.value = likeRes.liked
+
+        if (logRes.tripId) {
+            tripDetail.value = await getTripDetail(logRes.tripId)
+        }
+    } catch (e: any) {
+        console.error('Fetch Log Detail Error:', e)
+         if (e?.response?.status === 404) {
+             error.value = '존재하지 않는 게시글입니다.'
+         } else if (e?.response?.status === 403) {
+             error.value = '접근 권한이 없는 게시글입니다.'
+         } else {
+             error.value = '데이터를 불러오는데 실패했습니다.'
+         }
+    } finally {
+        isLoading.value = false
+    }
+}
+
+const handleUpdateLike = (payload: { logId: number; likeCount: number; liked: boolean }) => {
+    if (tripLog.value) {
+        tripLog.value.likeCount = payload.likeCount
+        isLiked.value = payload.liked
+    }
+}
+
+const navigateToUserLog = (userId: number) => {
+    router.push({ name: 'user-log', params: { userId } })
+}
+
+const handleLoginConfirm = () => {
+  isLoginAlertVisible.value = false
+  router.push({ name: 'login' })
+}
+
+const handleShare = () => {
+    const url = window.location.href
+    navigator.clipboard.writeText(url).then(() => {
+        showToast.value = true
+        setTimeout(() => showToast.value = false, 2000)
+    })
+}
+
+onMounted(fetchData)
+</script>
+
+<style scoped>
+/* No specific styles needed */
+</style>

--- a/src/views/TripLogDetailView.vue
+++ b/src/views/TripLogDetailView.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="min-h-screen bg-[#F5F5F5] font-sans">
+  <div class="min-h-screen bg-white font-sans">
     <TravelNavbar @navigate="handleNavigate" />
 
-    <div class="pt-24 max-w-4xl mx-auto px-4 pb-20">
-      <div v-if="isLoading" class="flex justify-center items-center h-[60vh]">
+    <div class="pt-32 max-w-3xl mx-auto px-6 pb-40">
+      <div v-if="isLoading" class="flex justify-center items-center h-[40vh]">
          <div class="w-12 h-12 border-[4px] border-[#2C2C2C] border-t-transparent rounded-full animate-spin"></div>
       </div>
 
-      <div v-else-if="error" class="flex flex-col items-center justify-center h-[60vh] text-center">
+      <div v-else-if="error" class="flex flex-col items-center justify-center h-[50vh] text-center">
         <p class="text-xl font-black text-red-500 mb-4">{{ error }}</p>
         <button
           @click="router.back()"
@@ -17,45 +17,148 @@
         </button>
       </div>
 
-      <div v-else-if="tripLog && tripDetail" class="bg-white rounded-xl shadow-[4px_4px_0px_0px_rgba(44,44,44,0.1)] overflow-hidden border-[2px] border-[#2C2C2C]">
-        <!-- Header -->
-        <div class="px-6 py-5 border-b-[2px] border-[#F0F0F0] bg-white flex items-center justify-between">
-           <div class="flex items-center gap-3 cursor-pointer hover:opacity-80 transition-opacity" @click="navigateToUserLog(tripLog!.authorId)">
-             <div class="w-12 h-12 border-[2px] border-[#2C2C2C] rounded-full overflow-hidden">
-               <img :src="tripLog.authorImageUrl" :alt="tripLog.authorNickname" class="w-full h-full object-cover" />
-             </div>
-             <div>
-                <h4 class="font-black text-lg text-[#2C2C2C]">{{ tripLog.authorNickname }}</h4>
-                <div class="flex items-center gap-2 text-xs font-bold text-gray-500">
-                  <span>{{ tripLog.locationSummary }}</span>
-                  <span>•</span>
-                  <span>{{ tripLog.createdAt.substring(0, 10) }}</span>
-                </div>
-             </div>
-           </div>
-           
-           <!-- Share Button -->
-           <button @click="handleShare" class="p-2 hover:bg-gray-100 rounded-lg transition-colors">
-              <Share2 class="w-5 h-5 text-[#2C2C2C]" />
-           </button>
-        </div>
+      <div v-else-if="tripLog && tripDetail">
+        <!-- Blog Header (Refined) -->
+        <header class="mb-10 text-center">
+             <!-- Row 1: Title -->
+            <h1 class="text-3xl md:text-4xl font-black text-[#2C2C2C] mb-6 leading-tight break-keep">
+                {{ tripLog.title }}
+            </h1>
+            
+            <!-- Row 2: Meta (Author, Date, Location) + Share -->
+            <div class="flex items-center justify-between border-b border-gray-200 pb-6">
+                 <div class="flex items-center gap-3">
+                    <div 
+                        class="w-10 h-10 border-[2px] border-[#2C2C2C] rounded-full overflow-hidden shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)] cursor-pointer hover:opacity-80"
+                        @click="navigateToUserLog(tripLog!.authorId)"
+                    >
+                        <img :src="tripLog.authorImageUrl" :alt="tripLog.authorNickname" class="w-full h-full object-cover" />
+                    </div>
+                    <div class="text-left">
+                         <div class="flex items-center gap-2">
+                             <span 
+                                class="font-black text-sm text-[#2C2C2C] cursor-pointer hover:underline"
+                                @click="navigateToUserLog(tripLog!.authorId)"
+                             >
+                                {{ tripLog.authorNickname }}
+                             </span>
+                         </div>
+                         <div class="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase tracking-wide">
+                            <span>{{ formattedDate }}</span>
+                            <span v-if="tripLog.locationSummary">•</span>
+                            <span v-if="tripLog.locationSummary">{{ tripLog.locationSummary }}</span>
+                        </div>
+                    </div>
+                 </div>
 
-        <!-- Content -->
-        <div class="min-h-[500px]">
+                 <!-- Share Button -->
+                 <button @click="handleShare" class="p-2 hover:bg-gray-100 rounded-lg transition-colors group" title="공유하기">
+                    <Share2 class="w-5 h-5 text-gray-400 group-hover:text-[#2C2C2C]" />
+                 </button>
+            </div>
+        </header>
+
+        <!-- Main Content -->
+        <div class="min-h-[200px] mb-16">
           <TripLogContent
             :log-detail="tripLog"
             :trip-detail="tripDetail"
             :initial-liked="isLiked"
             :show-header="false"
+            :hide-title="true"
+            :hide-comments="true"
             layout="vertical"
-            @update-like="handleUpdateLike"
-            @login-required="isLoginAlertVisible = true"
-            @refresh-comments="fetchData"
+            class="!h-auto !bg-transparent"
+             @place-click="(id) => {}"
+             @update-like="handleUpdateLikeFromContent"
           />
+        </div>
+
+        <!-- Static Comments Section -->
+        <div ref="commentSection" class="border-t border-gray-200 pt-10">
+            <div class="flex items-center gap-4 mb-8">
+                 <button
+                 @click="handleLike"
+                 :class="[
+                    'flex items-center gap-2 px-4 py-2 border-[2px] border-[#2C2C2C] rounded-full font-black text-sm transition-all',
+                    isLiked
+                     ? 'bg-[#FF6B9D] text-white shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]'
+                     : 'bg-white hover:bg-gray-50 hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]'
+                 ]"
+               >
+                 <Heart :class="['w-4 h-4', isLiked ? 'fill-current' : '']" stroke-width="2.5" />
+                 <span>{{ currentLikes }}</span>
+               </button>
+
+               <!-- Scrap Button -->
+               <button
+                 @click="handleScrap"
+                 class="flex items-center justify-center px-4 py-2 border-[2px] border-[#2C2C2C] rounded-full bg-white hover:bg-gray-50 hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)] transition-all group"
+               >
+                 <Bookmark class="w-4 h-5 text-[#2C2C2C]" stroke-width="2.5" />
+               </button>
+               
+               <button 
+                  @click="handleShare"
+                  class="flex items-center gap-2 px-4 py-2 border-[2px] border-[#2C2C2C] rounded-full font-black text-sm bg-white hover:bg-gray-50 hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)] transition-all"
+               >
+                  <Share2 class="w-4 h-5 text-[#2C2C2C]" stroke-width="2.5" />
+               </button>
+            </div>
+            
+            <h3 class="font-black text-xl text-[#2C2C2C] mb-6">댓글 <span class="text-[#FF6B9D]">{{ tripLog?.comments?.length || 0 }}</span></h3>
+            
+            <TripLogComments 
+                :comments="tripLog.comments"
+                :current-user-nickname="authStore.user?.nickname"
+                :current-user-profile-image="authStore.user?.profileImageUrl"
+                :is-logged-in="authStore.isLoggedIn"
+                @post-comment="handlePostComment"
+                @update-comment="handleUpdateComment"
+                @delete-comment="handleDeleteComment"
+                @login-required="isLoginAlertVisible = true"
+                @navigate-user="navigateToUserLog"
+                ref="tripLogCommentsRef"
+                class="!h-[400px]"
+            />
         </div>
       </div>
     </div>
     
+    <!-- Floating Bottom Bar -->
+    <Transition name="slide-up">
+        <div 
+            v-if="isFloatingBarVisible && tripLog" 
+            class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 py-3 px-6 z-40 flex items-center justify-center shadow-[0_-4px_20px_rgba(0,0,0,0.05)]"
+        >
+             <div class="max-w-3xl w-full flex items-center justify-between">
+                  <div class="flex items-center gap-3">
+                       <button
+                         @click="handleLike"
+                         :class="[
+                            'flex items-center gap-2 px-4 py-2 border-[2px] border-[#2C2C2C] rounded-full font-black text-sm transition-all',
+                            isLiked
+                             ? 'bg-[#FF6B9D] text-white shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]'
+                             : 'bg-white hover:bg-gray-50 hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)]'
+                         ]"
+                       >
+                         <Heart :class="['w-4 h-4', isLiked ? 'fill-current' : '']" stroke-width="2.5" />
+                         <span>{{ currentLikes }}</span>
+                       </button>
+
+                       <button
+                         @click="scrollToComments"
+                         class="flex items-center gap-2 px-4 py-2 border-[2px] border-[#2C2C2C] bg-white rounded-full font-black text-sm text-[#2C2C2C] hover:bg-gray-50 hover:shadow-[2px_2px_0px_0px_rgba(44,44,44,0.1)] transition-all"
+                       >
+                         <MessageCircle class="w-4 h-4" stroke-width="2.5" />
+                         <span>댓글 {{ tripLog.commentCount }}</span>
+                       </button>
+                  </div>
+             </div>
+        </div>
+    </Transition>
+
+    <!-- Modals -->
     <AlertDialog
       :is-open="isLoginAlertVisible"
       title="로그인 필요"
@@ -67,7 +170,6 @@
       @close="isLoginAlertVisible = false"
     />
 
-    <!-- Toast for copy link -->
      <Transition
       enter-active-class="transition-all duration-300 ease-out"
       leave-active-class="transition-all duration-200 ease-in"
@@ -78,8 +180,13 @@
     >
       <div
         v-if="showToast"
-        class="fixed top-24 right-6 z-[60] bg-white border-[3px] border-[#2C2C2C] rounded-xl shadow-[4px_4px_0px_0px_rgba(44,44,44,0.3)] px-5 py-3 flex items-center gap-3"
+        class="fixed top-24 right-6 z-[80] bg-white border-[3px] border-[#2C2C2C] rounded-xl shadow-[4px_4px_0px_0px_rgba(44,44,44,0.3)] px-5 py-3 flex items-center gap-3"
       >
+         <div class="w-6 h-6 bg-[#FFD60A] border-[2px] border-[#2C2C2C] rounded-full flex items-center justify-center flex-shrink-0">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M11.6666 3.5L5.24992 9.91667L2.33325 7" stroke="#2C2C2C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
          <span class="font-black text-sm text-[#2C2C2C]">링크가 복사되었습니다!</span>
       </div>
     </Transition>
@@ -87,18 +194,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted, computed, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import TravelNavbar from '@/components/common/TravelNavbar.vue'
 import TripLogContent from '@/components/trip-log/TripLogContent.vue'
+import TripLogComments from '@/components/trip-log/TripLogComments.vue'
 import AlertDialog from '@/components/common/AlertDialog.vue'
 import { useNavigate } from '@/composables/common/useNavagation'
-import { getTripLogDetail, getTripLogLikeStatus } from '@/apis/trip-log/index'
+import { getTripLogDetail, getTripLogLikeStatus, likeTripLog, unlikeTripLog, postTripLogComment, updateTripLogComment, deleteTripLogComment } from '@/apis/trip-log/index'
 import { getTripDetail } from '@/apis/trip/index'
-import { Share2 } from 'lucide-vue-next'
+import { Share2, Heart, MessageCircle, Bookmark } from 'lucide-vue-next'
 import { useAuthStore } from '@/stores/auth'
 import type { TripLogDetail } from '@/types/trip/trip.model'
 import type { TripDetailResponseDto } from '@/apis/trip/types'
+import { format, parseISO } from 'date-fns'
 
 const route = useRoute()
 const router = useRouter()
@@ -111,8 +220,19 @@ const error = ref<string | null>(null)
 const tripLog = ref<TripLogDetail | null>(null)
 const tripDetail = ref<TripDetailResponseDto | null>(null)
 const isLiked = ref(false)
+const currentLikes = ref(0)
 const isLoginAlertVisible = ref(false)
 const showToast = ref(false)
+const commentSection = ref<HTMLElement | null>(null)
+const tripLogCommentsRef = ref<any>(null)
+
+// UI States
+const isScrolledPastHeader = ref(false)
+const isCommentSectionVisible = ref(false)
+
+const isFloatingBarVisible = computed(() => {
+    return isScrolledPastHeader.value && !isCommentSectionVisible.value
+})
 
 const fetchData = async () => {
     isLoading.value = true
@@ -125,10 +245,11 @@ const fetchData = async () => {
         
         tripLog.value = {
             ...logRes,
-            logId: logId, // ensure ID
+            logId: logId, 
              authorId: logRes.authorId || 0
         }
         isLiked.value = likeRes.liked
+        currentLikes.value = logRes.likeCount
 
         if (logRes.tripId) {
             tripDetail.value = await getTripDetail(logRes.tripId)
@@ -147,12 +268,113 @@ const fetchData = async () => {
     }
 }
 
-const handleUpdateLike = (payload: { logId: number; likeCount: number; liked: boolean }) => {
-    if (tripLog.value) {
-        tripLog.value.likeCount = payload.likeCount
-        isLiked.value = payload.liked
+const formattedDate = computed(() => {
+  if (!tripLog.value?.createdAt) return ''
+  return format(parseISO(tripLog.value.createdAt), 'yyyy.MM.dd')
+})
+
+// Scroll Handler
+const handleScroll = () => {
+    const scrollY = window.scrollY
+    if (scrollY > 200) {
+        isScrolledPastHeader.value = true
+    } else {
+        isScrolledPastHeader.value = false
     }
 }
+
+let observer: IntersectionObserver | null = null
+
+const setupIntersectionObserver = () => {
+    if (!commentSection.value) return
+
+    observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+            isCommentSectionVisible.value = entry.isIntersecting
+        })
+    }, {
+        root: null, // viewport
+        threshold: 0.1 // Trigger when 10% of comment section is visible
+    })
+    
+    observer.observe(commentSection.value)
+}
+
+const scrollToComments = () => {
+    if (commentSection.value) {
+        commentSection.value.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        // Optionally focus input if available
+        nextTick(() => {
+            if(tripLogCommentsRef.value) {
+                tripLogCommentsRef.value.focusInput()
+            }
+        })
+    }
+}
+
+const handleLike = async () => {
+  if (!authStore.isLoggedIn) {
+     isLoginAlertVisible.value = true
+    return
+  }
+  if (!tripLog.value) return
+
+  try {
+    let response
+    if (isLiked.value) {
+      response = await unlikeTripLog(tripLog.value.logId)
+    } else {
+      response = await likeTripLog(tripLog.value.logId)
+    }
+    isLiked.value = response.liked
+    currentLikes.value = response.likeCount
+    
+    // Sync local object
+    tripLog.value.likeCount = response.likeCount
+  } catch (e) {
+    console.error('Failed to toggle like status:', e)
+    // Show error toast?
+  }
+}
+
+// Logic to handle updates from TripLogContent (if any, though we hid comments)
+const handleUpdateLikeFromContent = (payload: { likeCount: number; liked: boolean }) => {
+    isLiked.value = payload.liked
+    currentLikes.value = payload.likeCount
+}
+
+
+// Comment Handlers (Proxied to API)
+const handlePostComment = async (content: string) => {
+    if (!tripLog.value) return
+    try {
+        await postTripLogComment(tripLog.value.logId, { content })
+        // Refresh
+        const logRes = await getTripLogDetail(logId)
+        tripLog.value = { ...logRes, logId, authorId: logRes.authorId || 0 }
+    } catch(e) { console.error(e) }
+}
+
+const handleUpdateComment = async (id: number, content: string) => {
+    try {
+        await updateTripLogComment(id, { content })
+         // Refresh
+        const logRes = await getTripLogDetail(logId)
+        // @ts-ignore
+        tripLog.value = { ...logRes, logId, authorId: logRes.authorId || 0 }
+    } catch(e) { console.error(e) }
+}
+
+const handleDeleteComment = async (id: number) => {
+    try {
+        await deleteTripLogComment(id)
+         // Refresh
+        const logRes = await getTripLogDetail(logId)
+        // @ts-ignore
+        tripLog.value = { ...logRes, logId, authorId: logRes.authorId || 0 }
+    } catch(e) { console.error(e) }
+}
+
 
 const navigateToUserLog = (userId: number) => {
     router.push({ name: 'user-log', params: { userId } })
@@ -163,6 +385,10 @@ const handleLoginConfirm = () => {
   router.push({ name: 'login' })
 }
 
+const handleScrap = () => {
+    alert('아직 준비 중인 기능입니다!')
+}
+
 const handleShare = () => {
     const url = window.location.href
     navigator.clipboard.writeText(url).then(() => {
@@ -171,9 +397,31 @@ const handleShare = () => {
     })
 }
 
-onMounted(fetchData)
+onMounted(() => {
+    fetchData().then(() => {
+        // Wait for DOM
+        nextTick(() => {
+            setupIntersectionObserver()
+        })
+    })
+    window.addEventListener('scroll', handleScroll)
+})
+
+onUnmounted(() => {
+    window.removeEventListener('scroll', handleScroll)
+    if (observer) observer.disconnect()
+})
 </script>
 
 <style scoped>
-/* No specific styles needed */
+.slide-up-enter-active,
+.slide-up-leave-active {
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.slide-up-enter-from,
+.slide-up-leave-to {
+  transform: translateY(100%);
+  opacity: 0;
+}
 </style>

--- a/src/views/TripView.vue
+++ b/src/views/TripView.vue
@@ -74,7 +74,7 @@
     <TripDetailModal
       v-if="selectedTrip"
       :trip="selectedTrip"
-      @close="selectedTrip = null"
+      @close="router.back()"
       @edit="handleEditFromModal"
       @write="handleWriteLogFromModal"
       @edit-log="handleEditLogFromModal"
@@ -86,14 +86,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { Plus } from 'lucide-vue-next'
 import { useNavigate } from '@/composables/common/useNavagation'
 import TravelNavbar from '@/components/common/TravelNavbar.vue'
 import TripCard from '@/components/trip/TripCard.vue'
 import TripDetailModal from '@/components/modal/TripDetailModal.vue'
 import ScrollToTop from '@/components/common/ScrollToTop.vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { createTrip, getMyTrips, getTripDetail } from '@/apis/trip/index'
 import type { TripResponseDto, TripDetailResponseDto, TripItemResponseDto } from '@/apis/trip/types'
 import { TripStatus } from '@/types/common'
@@ -101,6 +101,7 @@ import type { TripLogDetail } from '@/types/trip/trip.model'
 
 const { handleNavigate } = useNavigate()
 const router = useRouter()
+const route = useRoute()
 
 const activeTab = ref<TripStatus | 'all'>('all')
 const tripsList = ref<TripResponseDto[]>([])
@@ -188,22 +189,39 @@ const formatMonth = (monthStr: string) => {
 // --- 핸들러 함수들 ---
 
 // 1. 모달 열기 로직
-const handleOpenModal = async (tripId: number) => {
-  try {
-    const detail = await getTripDetail(tripId)
-    selectedTrip.value = {
-      ...detail,
-      description:
-        detail.tripItems && detail.tripItems.length > 0
-          ? detail.tripItems.map((item : TripItemResponseDto) => item.spot.name).join(' → ')
-          : '장소 없음',
-    }
-  } catch (error) {
-    console.error(`여행 상세 조회 실패 (ID: ${tripId}):`, error)
-    alert('여행 상세 정보를 불러오는데 실패했습니다.')
-    selectedTrip.value = null
-  }
+const handleOpenModal = (tripId: number) => {
+    router.push({ query: { ...route.query, tripId } })
 }
+
+const fetchTripDetailAndOpen = async (tripId: number) => {
+    console.log('TripView: fetching detail for', tripId)
+    try {
+        const detail = await getTripDetail(tripId)
+        selectedTrip.value = {
+            ...detail,
+             description:
+                detail.tripItems && detail.tripItems.length > 0
+                ? detail.tripItems.map((item : TripItemResponseDto) => item.spot.name).join(' → ')
+                : '장소 없음',
+        }
+        console.log('TripView: selectedTrip set', selectedTrip.value)
+
+    } catch (error) {
+        console.error(`여행 상세 조회 실패 (ID: ${tripId}):`, error)
+        alert('여행 상세 정보를 불러오는데 실패했습니다.')
+        selectedTrip.value = null
+        router.replace({ query: { ...route.query, tripId: undefined } }) // Remove invalid ID
+    }
+}
+
+watch(() => route.query.tripId, async (newTripId) => {
+    console.log('TripView: watcher triggered with', newTripId)
+    if (newTripId) {
+        await fetchTripDetailAndOpen(Number(newTripId))
+    } else {
+        selectedTrip.value = null
+    }
+}, { immediate: true })
 
 // 2. TripPlanView로 이동
 const handleEditFromModal = (trip: TripDetailResponseDto) => {


### PR DESCRIPTION
## Issue
- #69 
- [x] 다른 계정 프로필 누르면 이동하게 하기
- [x] 다른 링크로 이동하고 뒤로가기 해도 모달이 뜬 상태로 남아있게 하기
- [x] 모달 edit plan 버튼 연결
- [x] 로그 모달에서 전체 페이지 누르면 해당 글 전체 페이지로 이동하게 하기

## Screen Shots
<img width="500" height="" alt="image" src="https://github.com/user-attachments/assets/f99f666d-c542-4995-bda1-88b6185ae884" />

<img width="800" height="" alt="image" src="https://github.com/user-attachments/assets/ed1613d0-3fc8-42a5-80c8-defaf43d0de8" />

<img width="800" height="" alt="image" src="https://github.com/user-attachments/assets/c44aa9c8-ef7b-407c-9c6f-060ebb9e7da2" />

아직 로그 페이지 구현이 덜 끝났습니다. 다른 기능 구현 이후 리팩토링할 예정입니다.
