### PR TITLE
refactor: 로그 페이지 카드 api 연동 및 페이지네이션 적용

### DIFF
--- a/src/apis/trip-log/index.ts
+++ b/src/apis/trip-log/index.ts
@@ -156,6 +156,26 @@ export const getTripLogsBySpot = async (
 }
 
 /**
+ * 특정 유저(userId)의 여행 로그 목록을 조회합니다.
+ * @param userId 유저 ID
+ * @param params 페이징 파라미터 (page, limit)
+ * @returns 여행 로그 목록 (PageTripLogFeedResponseDto)
+ */
+export const getTripLogsByUser = async (
+  userId: number,
+  params: { page?: number; limit?: number }
+): Promise<any> => {
+  const response = await apiClient.get('/trip-logs', {
+    params: {
+      userId,
+      page: params.page ?? 1,
+      limit: params.limit ?? 10
+    }
+  })
+  return response.data
+}
+
+/**
  * 여행 로그 생성 API 함수
  * @param payload 여행 로그 생성 요청 데이터
  * @returns 생성된 로그 ID

--- a/src/apis/trip/types.ts
+++ b/src/apis/trip/types.ts
@@ -125,6 +125,8 @@ export interface TripDiaryResponseDto {
   endDate: string | null;
   likes: number;
   comments: number;
+  content?: string;
+  createdAt?: string;
 }
 
 export interface LogDiaryDto extends TripDiaryResponseDto {

--- a/src/apis/user/types.ts
+++ b/src/apis/user/types.ts
@@ -71,6 +71,10 @@ export interface UserLogSummaryDto {
     logId: number
     title: string
     thumbnailUrl: string | null
+    content?: string
+    createdAt?: string // 로그 작성일
+    likes?: number
+    comments?: number
 }
 
 export type UserProfileResponseDto = BaseUserProfileDto
@@ -78,18 +82,18 @@ export type UserProfileResponseDto = BaseUserProfileDto
 export type UserFriendsResponseDto = BaseUserProfileDto[]
 
 export interface UserMeResponseDto
-  extends BaseUserProfileDto {
-  email: string
+    extends BaseUserProfileDto {
+    email: string
 }
 
 export interface UserAIAnalysisResponseDto {
-  keywords : string[]
-  summary: string
-  scores: {
-    rest: number
-    exploration: number
-    activity: number
-    gourmet: number
-  }
+    keywords: string[]
+    summary: string
+    scores: {
+        rest: number
+        exploration: number
+        activity: number
+        gourmet: number
+    }
 }
 

--- a/src/components/log/LogContentTabs.vue
+++ b/src/components/log/LogContentTabs.vue
@@ -97,6 +97,20 @@ const handleDiaryClick = async (tripId: number) => {
     isLoadingDetail.value = false
   }
 }
+
+// Helpers
+const stripHtml = (html?: string) => {
+  if (!html) return ''
+  const tmp = document.createElement('DIV')
+  tmp.innerHTML = html
+  return tmp.textContent || tmp.innerText || ''
+}
+
+const formatDate = (dateStr?: string) => {
+    if (!dateStr) return '날짜 미정'
+    const date = new Date(dateStr)
+    return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`
+}
 </script>
 
 
@@ -176,16 +190,15 @@ const handleDiaryClick = async (tripId: number) => {
                 <div class="p-4 flex-1 flex flex-col">
                   <h3 class="font-black text-xl text-[#2C2C2C] mb-2 truncate">{{ card.title }}</h3>
                   <p class="text-sm text-gray-600 mb-3 line-clamp-2 h-10">
-                    {{
-                      card.spotPreviews && card.spotPreviews.length > 0
-                      ? card.spotPreviews.map(s => s.name).join(', ') : '아직 방문지가 없습니다.' }}</p>
+                    {{ card.content ? stripHtml(card.content) : '내용이 없습니다.' }}
+                  </p>
                   <div v-if="card.tags" class="flex flex-wrap gap-1 mb-3 h-5 overflow-hidden">
                     <span v-for="tag in card.tags" :key="tag"
                           class="bg-gray-100 text-gray-700 text-xs font-semibold px-2 py-0.5 rounded-full"
                     >#{{ tag }}</span>
                   </div>
                   <div class="mt-auto text-xs text-gray-500 flex justify-between items-center">
-                    <span>{{ card.startDate && card.endDate ? `${card.startDate} ~ ${card.endDate}` : '날짜 미정' }}</span>
+                    <span>{{ formatDate(card.createdAt) }}</span>
                     <div class="flex items-center gap-2">
                       <span class="flex items-center text-gray-600"><Heart class="w-4 h-4 mr-1" />{{ card.likes || 0 }}</span>
                       <span class="flex items-center text-gray-600"><MessageCircle class="w-4 h-4 mr-1" />{{ card.comments || 0 }}</span>

--- a/src/components/log/LogContentTabs.vue
+++ b/src/components/log/LogContentTabs.vue
@@ -12,7 +12,7 @@ import type {
 
 import { createTrip, getTripDetail } from '@/apis/trip/index'
 import type { LogDiaryDto } from '@/apis/trip/types'
-import { Heart, MessageCircle } from 'lucide-vue-next'
+import { Heart, MessageCircle, ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import TripCard from '@/components/trip/TripCard.vue'
 import TripDetailModal from '@/components/modal/TripDetailModal.vue'
 import { handleImageError } from '@/utils/imageHandler'
@@ -22,6 +22,8 @@ interface Props {
   isMyProfile: boolean
   userDiaries: (LogDiaryDto | UserLogSummaryDto)[]
   userPlans: TripPlanView[]
+  currentPage?: number
+  totalPages?: number
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -98,6 +100,8 @@ const handleDiaryClick = async (tripId: number) => {
   }
 }
 
+const emit = defineEmits(['page-change'])
+
 // Helpers
 const stripHtml = (html?: string) => {
   if (!html) return ''
@@ -173,40 +177,73 @@ const formatDate = (dateStr?: string) => {
               새 일기 쓰기
             </button>
           </div>
-          <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-12">
-              <div v-for="card in normalizedDiaries" :key="card.tripId"
-                  @click="handleDiaryClick(card.tripId)"
-                  class="cursor-pointer bg-white border-[2px] border-[#2C2C2C] rounded-2xl shadow-[4px_4px_0px_0px_rgba(44,44,44,0.15)] flex flex-col overflow-hidden transition-transform hover:scale-105"
-              >
-                <div class="relative w-full h-40">
-                  <img :src="card.thumbnailUrl || '/default-profile.svg'" :alt="card.title" class="w-full h-full object-cover" @error="handleImageError($event, 'thumbnail')">
-                   <span v-if="card.visibility === 'PRIVATE'" class="absolute top-2 right-2 bg-red-500 text-white text-xs font-bold px-2 py-1 rounded-full">
-                    PRIVATE
-                  </span>
-                  <span class="absolute top-2 left-2 bg-[#9BCCC4] text-[#2C2C2C] text-xs font-bold px-2 py-1 rounded-full">
-                    DIARY
-                  </span>
-                </div>
-                <div class="p-4 flex-1 flex flex-col">
-                  <h3 class="font-black text-xl text-[#2C2C2C] mb-2 truncate">{{ card.title }}</h3>
-                  <p class="text-sm text-gray-600 mb-3 line-clamp-2 h-10">
-                    {{ card.content ? stripHtml(card.content) : '내용이 없습니다.' }}
-                  </p>
-                  <div v-if="card.tags" class="flex flex-wrap gap-1 mb-3 h-5 overflow-hidden">
-                    <span v-for="tag in card.tags" :key="tag"
-                          class="bg-gray-100 text-gray-700 text-xs font-semibold px-2 py-0.5 rounded-full"
-                    >#{{ tag }}</span>
-                  </div>
-                  <div class="mt-auto text-xs text-gray-500 flex justify-between items-center">
-                    <span>{{ formatDate(card.createdAt) }}</span>
-                    <div class="flex items-center gap-2">
-                      <span class="flex items-center text-gray-600"><Heart class="w-4 h-4 mr-1" />{{ card.likes || 0 }}</span>
-                      <span class="flex items-center text-gray-600"><MessageCircle class="w-4 h-4 mr-1" />{{ card.comments || 0 }}</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-          </div>
+            <div v-else>
+               <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-12 mb-12 min-h-[1000px] content-start">
+                   <div v-for="card in normalizedDiaries" :key="card.tripId"
+                       @click="handleDiaryClick(card.tripId)"
+                       class="cursor-pointer bg-white border-[2px] border-[#2C2C2C] rounded-2xl shadow-[4px_4px_0px_0px_rgba(44,44,44,0.15)] flex flex-col overflow-hidden transition-transform hover:scale-105"
+                   >
+                     <div class="relative w-full h-40">
+                       <img :src="card.thumbnailUrl || '/default-profile.svg'" :alt="card.title" class="w-full h-full object-cover" @error="handleImageError($event, 'thumbnail')">
+                        <span v-if="card.visibility === 'PRIVATE'" class="absolute top-2 right-2 bg-red-500 text-white text-xs font-bold px-2 py-1 rounded-full">
+                         PRIVATE
+                       </span>
+                       <span class="absolute top-2 left-2 bg-[#9BCCC4] text-[#2C2C2C] text-xs font-bold px-2 py-1 rounded-full">
+                         DIARY
+                       </span>
+                     </div>
+                     <div class="p-4 flex-1 flex flex-col">
+                       <h3 class="font-black text-xl text-[#2C2C2C] mb-2 truncate">{{ card.title }}</h3>
+                       <p class="text-sm text-gray-600 mb-3 line-clamp-2 h-10">
+                         {{ card.content ? stripHtml(card.content) : '내용이 없습니다.' }}
+                       </p>
+                       <div v-if="card.tags" class="flex flex-wrap gap-1 mb-3 h-5 overflow-hidden">
+                         <span v-for="tag in card.tags" :key="tag"
+                               class="bg-gray-100 text-gray-700 text-xs font-semibold px-2 py-0.5 rounded-full"
+                         >#{{ tag }}</span>
+                       </div>
+                       <div class="mt-auto text-xs text-gray-500 flex justify-between items-center">
+                         <span>{{ formatDate(card.createdAt) }}</span>
+                         <div class="flex items-center gap-2">
+                           <span class="flex items-center text-gray-600"><Heart class="w-4 h-4 mr-1" />{{ card.likes || 0 }}</span>
+                           <span class="flex items-center text-gray-600"><MessageCircle class="w-4 h-4 mr-1" />{{ card.comments || 0 }}</span>
+                         </div>
+                       </div>
+                     </div>
+                   </div>
+               </div>
+
+               <!-- Pagination -->
+               <div v-if="totalPages && totalPages > 1" class="flex justify-center items-center gap-2">
+                 <button
+                   @click="emit('page-change', currentPage! - 1)"
+                   :disabled="currentPage === 1"
+                   class="p-2 rounded-full hover:bg-gray-100 disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+                 >
+                   <ChevronLeft class="w-5 h-5" />
+                 </button>
+                 
+                 <div class="flex gap-1">
+                   <button
+                     v-for="page in totalPages"
+                     :key="page"
+                     @click="emit('page-change', page)"
+                     class="w-8 h-8 rounded-full text-sm font-bold transition-all"
+                     :class="currentPage === page ? 'bg-[#2C2C2C] text-white' : 'hover:bg-gray-100 text-gray-600'"
+                   >
+                     {{ page }}
+                   </button>
+                 </div>
+
+                 <button
+                   @click="emit('page-change', currentPage! + 1)"
+                   :disabled="currentPage === totalPages"
+                   class="p-2 rounded-full hover:bg-gray-100 disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+                 >
+                   <ChevronRight class="w-5 h-5" />
+                 </button>
+               </div>
+           </div>
         </div>
       </div>
     </div>

--- a/src/mappers/userProfile.mapper.ts
+++ b/src/mappers/userProfile.mapper.ts
@@ -7,7 +7,7 @@ export function toLogViewProfile(
     data: BaseUserProfileDto,
     isMyProfile: boolean,
     email?: string
-    ): LogViewProfile {
+): LogViewProfile {
     return {
         id: data.id,
         nickname: data.nickname,
@@ -20,23 +20,25 @@ export function toLogViewProfile(
         travelStyleSummary: data.travelStyleSummary,
         completedTrips: data.completedTripDetails,
         userPlans: data.tripOverviews.map(plan => ({
-          ...plan,
-          likes: 0,
-          comments: 0,
+            ...plan,
+            likes: 0,
+            comments: 0,
         })),
         // logs를 TripDiaryResponseDto 형태로 변환
         diaries: data.logs.map(log => ({
-          id: log.logId,
-          tripId: log.tripId,
-          title: log.title,
-          thumbnailUrl: log.thumbnailUrl,
-          visibility: 'PUBLIC',
-          spotPreviews: [],
-          tags: [],
-          startDate: null,
-          endDate: null,
-          likes: 0,
-          comments: 0,
+            id: log.logId,
+            tripId: log.tripId,
+            title: log.title,
+            thumbnailUrl: log.thumbnailUrl,
+            visibility: 'PUBLIC',
+            spotPreviews: [],
+            tags: [],
+            startDate: null,
+            endDate: null,
+            likes: log.likes || 0,
+            comments: log.comments || 0,
+            content: log.content,
+            createdAt: log.createdAt
         })),
     }
 }
@@ -55,8 +57,10 @@ export function normalizeDiary(diary: LogDiaryDto | UserLogSummaryDto): LogDiary
             tags: [],
             startDate: null,
             endDate: null,
-            likes: 0,
-            comments: 0
+            likes: diary.likes || 0,
+            comments: diary.comments || 0,
+            content: diary.content,
+            createdAt: diary.createdAt
         };
     }
     // 이미 TripDiaryResponseDto인 경우

--- a/src/views/LogView.vue
+++ b/src/views/LogView.vue
@@ -24,6 +24,8 @@ const route = useRoute()
 const loggedInUser = computed(() => authStore.user)
 const profileData = ref<LogViewProfile | null>(null)
 const isLoading = ref(true)
+const currentPage = ref(1)
+const totalPages = ref(1)
 
 const isMyProfile = computed<boolean>(() => {
   const routeUserId = route.params.userId
@@ -38,41 +40,7 @@ const fetchAndSetProfileData = async (userId: number, showLoading = true) => {
     const response = await fetchUserProfile(userId);
     if (response){
       profileData.value = toLogViewProfile(response, false)
-      
-      // Fetch rich logs
-      try {
-        const logsRes = await getTripLogsByUser(userId, { limit: 100 }) // Load enough for preview
-        if (logsRes && logsRes.content) {
-            profileData.value.diaries = logsRes.content.map((log: any) => ({
-                id: log.logId,
-                tripId: log.tripId || 0, // tripId might not be in feed dto? Check spec. Spec says tripId is in Detail, but LogFeedDto doesn't explicitly show it in user's pasted spec (TripLogFeedResponseDto). Wait. The pasted spec shows TripLogFeedResponseDto having logId, authorId. No tripId?
-                // Actually TripLogFeedResponseDto doesn't show tripId in user's paste.
-                // But LogDiaryDto needs tripId for click handler?
-                // userLogSummaryDto had tripId.
-                // If feed doesn't have tripId, we might lose navigation capability if not careful.
-                // Let's assume for now we use 0 or try to preserve if possible.
-                // Re-reading spec: TripLogSearchDoc has trip_id. TripLogDetail has tripId.
-                // TripLogFeedResponseDto in user paste: logId, authorId, title, content... NO tripId.
-                // This is a problem if `handleDiaryClick(card.tripId)` relies on it.
-                // LogContentTabs: `handleDiaryClick(card.tripId)`.
-                // It calls `getTripDetail(tripId)`.
-                // This means the card MUST HAVE tripId.
-                // If `TripLogFeedResponseDto` lacks tripId, we can't fully substitute it.
-                // But `UserLogSummaryDto` (from profile) HAS `tripId`.
-                // Maybe we can merge?
-                // Match by logId.
-                ...log,
-                id: log.logId,
-                likes: log.likeCount,
-                comments: log.commentCount,
-                thumbnailUrl: log.images && log.images.length > 0 ? log.images[0].imageUrl : null,
-                // Reserve tripId from existing summary if available
-                tripId: profileData.value?.diaries.find(d => d.id === log.logId)?.tripId || 0
-            }))
-        }
-      } catch (e) {
-        console.error("Failed to fetch rich logs", e)
-      }
+      await fetchLogs(userId, 1)
     }
   } catch (error) {
     console.error(`Failed to fetch profile for user ${userId}:`, error);
@@ -80,6 +48,28 @@ const fetchAndSetProfileData = async (userId: number, showLoading = true) => {
   } finally {
     if (showLoading) isLoading.value = false
   }
+}
+
+const fetchLogs = async (userId: number, page: number) => {
+    try {
+        const logsRes = await getTripLogsByUser(userId, { page, limit: 9 })
+        if (logsRes && logsRes.content) {
+            if (profileData.value) {
+                profileData.value.diaries = logsRes.content.map((log: any) => ({
+                    ...log,
+                    id: log.logId,
+                    likes: log.likeCount,
+                    comments: log.commentCount,
+                    thumbnailUrl: log.images && log.images.length > 0 ? log.images[0].imageUrl : null,
+                    tripId: profileData.value?.diaries.find(d => d.id === log.logId)?.tripId || 0
+                }))
+            }
+            currentPage.value = page
+            totalPages.value = logsRes.totalPages
+        }
+    } catch (e) {
+        console.error("Failed to fetch logs", e)
+    }
 }
 
 const setMyProfileData = async (showLoading = true) => {
@@ -94,29 +84,21 @@ const setMyProfileData = async (showLoading = true) => {
         const response = await requestFetchUser()
         if (response){
           profileData.value = toLogViewProfile(response, true)
-          
-           // Fetch rich logs for me
-          try {
-            const logsRes = await getTripLogsByUser(loggedInUser.value.id, { limit: 100 })
-            if (logsRes && logsRes.content) {
-                profileData.value.diaries = logsRes.content.map((log: any) => ({
-                    ...log,
-                    id: log.logId,
-                    likes: log.likeCount,
-                    comments: log.commentCount,
-                     thumbnailUrl: log.images && log.images.length > 0 ? log.images[0].imageUrl : null,
-                     tripId: profileData.value?.diaries.find(d => d.id === log.logId)?.tripId || 0
-                }))
-            }
-          } catch (e) {
-            console.error("Failed to fetch rich logs for me", e)
-          }
+          await fetchLogs(loggedInUser.value.id, 1)
         }
     } catch (error) {
         console.error('내 프로필 정보를 가져오는 데 실패했습니다.', error);
         if (showLoading) profileData.value = null;
     } finally {
         if (showLoading) isLoading.value = false;
+    }
+}
+
+const handlePageChange = async (page: number) => {
+    if (profileData.value) {
+        await fetchLogs(profileData.value.id, page)
+         // Scroll to top of tabs? Optional.
+        window.scrollTo({ top: 300, behavior: 'smooth' })
     }
 }
 
@@ -174,6 +156,9 @@ onMounted(() => {
             :is-my-profile="isMyProfile"
             :user-diaries="profileData.diaries || []"
             :user-plans="profileData.userPlans || []"
+            :current-page="currentPage"
+            :total-pages="totalPages"
+            @page-change="handlePageChange"
           />
         </section>
       </div>

--- a/src/views/LogView.vue
+++ b/src/views/LogView.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router'
 import { useNavigate } from '@/composables/common/useNavagation'
 import { useAuthStore } from '@/stores/auth'
 import { fetchUserProfile, requestFetchUser } from '@/apis/user/index'
+import { getTripLogsByUser } from '@/apis/trip-log/index'
 import TravelNavbar from '@/components/common/TravelNavbar.vue'
 import ScrollToTop from '@/components/common/ScrollToTop.vue'
 import FriendsListModal from '@/components/log/FriendsListModal.vue'
@@ -37,6 +38,41 @@ const fetchAndSetProfileData = async (userId: number, showLoading = true) => {
     const response = await fetchUserProfile(userId);
     if (response){
       profileData.value = toLogViewProfile(response, false)
+      
+      // Fetch rich logs
+      try {
+        const logsRes = await getTripLogsByUser(userId, { limit: 100 }) // Load enough for preview
+        if (logsRes && logsRes.content) {
+            profileData.value.diaries = logsRes.content.map((log: any) => ({
+                id: log.logId,
+                tripId: log.tripId || 0, // tripId might not be in feed dto? Check spec. Spec says tripId is in Detail, but LogFeedDto doesn't explicitly show it in user's pasted spec (TripLogFeedResponseDto). Wait. The pasted spec shows TripLogFeedResponseDto having logId, authorId. No tripId?
+                // Actually TripLogFeedResponseDto doesn't show tripId in user's paste.
+                // But LogDiaryDto needs tripId for click handler?
+                // userLogSummaryDto had tripId.
+                // If feed doesn't have tripId, we might lose navigation capability if not careful.
+                // Let's assume for now we use 0 or try to preserve if possible.
+                // Re-reading spec: TripLogSearchDoc has trip_id. TripLogDetail has tripId.
+                // TripLogFeedResponseDto in user paste: logId, authorId, title, content... NO tripId.
+                // This is a problem if `handleDiaryClick(card.tripId)` relies on it.
+                // LogContentTabs: `handleDiaryClick(card.tripId)`.
+                // It calls `getTripDetail(tripId)`.
+                // This means the card MUST HAVE tripId.
+                // If `TripLogFeedResponseDto` lacks tripId, we can't fully substitute it.
+                // But `UserLogSummaryDto` (from profile) HAS `tripId`.
+                // Maybe we can merge?
+                // Match by logId.
+                ...log,
+                id: log.logId,
+                likes: log.likeCount,
+                comments: log.commentCount,
+                thumbnailUrl: log.images && log.images.length > 0 ? log.images[0].imageUrl : null,
+                // Reserve tripId from existing summary if available
+                tripId: profileData.value?.diaries.find(d => d.id === log.logId)?.tripId || 0
+            }))
+        }
+      } catch (e) {
+        console.error("Failed to fetch rich logs", e)
+      }
     }
   } catch (error) {
     console.error(`Failed to fetch profile for user ${userId}:`, error);
@@ -58,6 +94,23 @@ const setMyProfileData = async (showLoading = true) => {
         const response = await requestFetchUser()
         if (response){
           profileData.value = toLogViewProfile(response, true)
+          
+           // Fetch rich logs for me
+          try {
+            const logsRes = await getTripLogsByUser(loggedInUser.value.id, { limit: 100 })
+            if (logsRes && logsRes.content) {
+                profileData.value.diaries = logsRes.content.map((log: any) => ({
+                    ...log,
+                    id: log.logId,
+                    likes: log.likeCount,
+                    comments: log.commentCount,
+                     thumbnailUrl: log.images && log.images.length > 0 ? log.images[0].imageUrl : null,
+                     tripId: profileData.value?.diaries.find(d => d.id === log.logId)?.tripId || 0
+                }))
+            }
+          } catch (e) {
+            console.error("Failed to fetch rich logs for me", e)
+          }
         }
     } catch (error) {
         console.error('내 프로필 정보를 가져오는 데 실패했습니다.', error);


### PR DESCRIPTION
카드 본문과 좋아요 댓글 상태를 api 연동했습니다.
페이지네이션 적용해 최대 3줄까지 보일 수 있게 하고 그 다음은 다음 페이지로 넘어가게 했습니다.

<img width="700" height="" alt="image" src="https://github.com/user-attachments/assets/16ccd248-5acd-4118-8308-1480aa3db5df" />

<img width="400" height="" alt="image" src="https://github.com/user-attachments/assets/03475dfe-33a4-4088-9692-c8e20cf9f80e" />
